### PR TITLE
Add download link for gamepad-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sudo apt install jstest-gtk
 jstest-gtk  # to run
 ```
 
-To use Yoke effectively with SDL-based games (e.g. all games using Unreal Engine or Unity3D), you can install the SDL gamepad tool.
+To use Yoke effectively with SDL-based games (e.g. all games using Unreal Engine or Unity3D), you can install the SDL gamepad tool. (If the package is not found, [download the tool from the website](http://generalarcade.com/gamepadtool/).)
 ```bash
 sudo apt install gamepadtool
 gamepadtool   # to run


### PR DESCRIPTION
I’m on latest Ubuntu and the gamepadtool package could not be found:
```
jan@Rechenknecht:~$ sudo apt install gamepadtool
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package gamepadtool
```

So I added the manual download link too in case others have the issue too. I’m assuming it’s this, which is called `gamepad-tool` with a dash (couldn’t find that as a package either though).