### PR TITLE
Compare strings properly in setup.py - fixes #14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='yoke',
       install_requires=[
             # 'numpy',
             'zeroconf',
-            *(['python-uinput'] if system() is 'Linux' else [])
+            *(['python-uinput'] if system() == 'Linux' else [])
             ],
       extras_require={
 


### PR DESCRIPTION
Comparing strings using `is` is like comparing char pointers in C - may work for constant string literals, but usually returns false. More info: https://stackoverflow.com/questions/1504717/why-does-comparing-strings-in-python-using-either-or-is-sometimes-produce