### PR TITLE
Increasing compatibility and functionality of the JavaScript controller

### DIFF
--- a/assets/joypad/base.css
+++ b/assets/joypad/base.css
@@ -2,6 +2,8 @@
 
 body {
     margin: 0;
+    padding: 0;
+    overflow: clip;
 }
 
 #joypad {
@@ -13,4 +15,7 @@ body {
 .circle {
     position: fixed;
     transform: translate(-50%, -50%);
+}
+#dbg {
+    overflow: clip;
 }

--- a/assets/joypad/main.html
+++ b/assets/joypad/main.html
@@ -5,13 +5,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="base.css" />
-    <link rel="stylesheet" type="text/css" href="user-default.css" />
     <link rel="stylesheet" type="text/css" href="user.css" />
-    <script type="application/javascript" src="base.js"></script>
 </head>
 
 <body>
-    <div id="joypad"></div>
+    <div id="joypad">If you don't see any controls, please <a href="https://play.google.com/store/apps/details?id=com.google.android.webview">upgrade Android WebView</a>, then reboot your device.</div>
+    <script type="application/javascript" src="base.js"></script>
 </body>
 
 </html>

--- a/assets/joypad/user-default.css
+++ b/assets/joypad/user-default.css
@@ -1,20 +1,29 @@
-/* Settings that user may want to modify */
+/* These are the default settings, PLEASE DO NOT MODIFY.
+Copy this file to user.css and change that. */
 
 #joypad {
     grid-template-columns: repeat(16, 1fr);
     grid-template-rows: repeat(9, 1fr);
     grid-template-areas:
-/*       .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   */
+    /* The map below must match the number of rows and columns specified above: */
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
-        ".   jl  jl  jl  .   .   .   .   .   .   .   .   .   b4  .   .   "
-        ".   jl  jl  jl  .   .   .   .   .   .   .   .   b3  .   b2  .   "
-        ".   jl  jl  jl  .   .   .   .   .   .   .   .   .   b1  .   .   "
-        ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
-        ".   .   .   .   .   .   .   .   .   jr  jr  jr  .   .   .   .   "
-        ".   .   .   .   .   .   .   .   .   jr  jr  jr  .   .   .   .   "
-        ".   .   .   .   .   .   .   .   .   jr  jr  jr  .   .   .   .   "
+        ".   .   .   .   .   .   .   .   .   .   .   .   b4  b4  .   .   "
+        ".   jl  jl  jl  .   .   .   .   .   .   .   .   b4  b4  .   .   "
+        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   jr  jr  jr  .   .   .   .   .   .   .   "
         "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
         ;
+        /* Possible values:
+         * jl for joystick, left;
+         * jr for joystick, right;
+         * cr for compass (gyrometer), right (VERY EXPERIMENTAL);
+         * b1 to b16 for buttons;
+         * dbg for debug messages;
+         * a period for empty space.
+         More to come */
 }
 
 .control {
@@ -29,9 +38,16 @@
 }
 
 #jl {
-    animation-name: locking;
+    /* Uncomment the line below if you don't want the joystick to return to center when let go */
+    /* animation-name: blocking; */
 }
-
 #jr {
-    animation-name: none;
+    /* Uncomment the line below if you don't want the joystick to return to center when let go */
+    animation-name: blocking;
 }
+#cr {background-color: #dddddd;}
+
+#b1 {background-color: #2222ee;}
+#b2 {background-color: #ee0000;}
+#b3 {background-color: #dddd00;}
+#b4 {background-color: #00dd00;}

--- a/assets/joypad/user.css
+++ b/assets/joypad/user.css
@@ -1,1 +1,55 @@
-/* Put your settings here. Use layout.css as a reference */
+/* Settings that the user may want to modify.
+ A copy of this file is bundled with yoke, named user-default.css
+ Please use that copy as a backup if your controller stops working. */
+
+#joypad {
+    grid-template-columns: repeat(16, 1fr);
+    grid-template-rows: repeat(9, 1fr);
+    grid-template-areas:
+    /* The map below must match the number of rows and columns specified above: */
+        ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
+        ".   .   .   .   .   .   .   .   .   .   .   .   b4  b4  .   .   "
+        ".   jl  jl  jl  .   .   .   .   .   .   .   .   b4  b4  .   .   "
+        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   jr  jr  jr  .   .   .   .   .   .   .   "
+        "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
+        ;
+        /* Possible values:
+         * jl for joystick, left;
+         * jr for joystick, right;
+         * cr for compass (gyrometer), right (VERY EXPERIMENTAL);
+         * b1 to b16 for buttons;
+         * dbg for debug messages;
+         * a period for empty space.
+         More to come */
+}
+
+.control {
+    background-color: #bbb;
+}
+
+.circle {
+    background-color: black;
+    width: 10px;
+    height: 10px;
+    border-radius: 100%;
+}
+
+#jl {
+    /* Uncomment the line below if you don't want the joystick to return to center when let go */
+    /* animation-name: blocking; */
+}
+#jr {
+    /* Uncomment the line below if you don't want the joystick to return to center when let go */
+    animation-name: blocking;
+}
+
+#cr {background-color: #dddddd;}
+
+#b1 {background-color: #2222ee;}
+#b2 {background-color: #ee0000;}
+#b3 {background-color: #dddd00;}
+#b4 {background-color: #00dd00;}


### PR DESCRIPTION
This is related to issues #2 and #17. This pull request is not compatible with my previous one because I wasn't sure if you would accept it. Also because I'm trying to learn to keep different changes separate.

I own an old low-end mobile, running Android Marshmallow, on which the controller wouldn't display. Its manufacturer has given up on publishing updates.

So while trying to get it to work and adding more functions, I made big changes on pzmarzly's code:

- Downgraded it from ECMAScript 6 to ECMAScript 5. I could ''not'' get it to display anything in the WebView otherwise. (Oddly, Firefox displayed it correctly, but not Android WebView even after upgrading it.) The code is more verbose now, but it should work the same way and be compatible with more devices.
- `base.js` now detects if Android WebView is too old to support CSS grids; if so, it displays a short note with a link, prompting the user to upgrade it.
- It also detects if `grid-template-areas` contains no controls (or is not there at all ― sometimes my mobile refused to download `user.css` after numerous connections).
- I moved the right joystick around, made the buttons bigger, and coloured them in.
- `base.js` only binds event handlers for the controls in `grid-template-areas`, and also doesn't bind `ontouch` for digital buttons (`ontouchstart` and `ontouchend` are enough).
- All controls vibrate just a little when you touch or release them, to have some sort of tactile feedback. This vibration can be changed or disabled changing two variables in `base.js`.
- Joysticks also vibrate when you try to push them past them limits. I think there is a lot of room for improvement here, but I'm not sure on what direction to take. Maybe vibrating every time you move it between quadrants?
- Tried to add a roll-pitch controller only to realize my mobile doesn't support it. I left the code in in case someone can test and improve it, but it's not active by default ― as far as I know, you need to replace a joystick with it.

I'm happy to keep adding new controls, but I need some direction, and the mapping to virtual controls is weird. `yoke.py` still has four modes of operation, and the actual order of axes and buttons seems to depend on `yoke.py`, `service.py` and `app-debug.apk` at the same time. It would be great if there was a way to unify them all (and only having to deal with the HTML part), but it's a very complex script and I'm afraid I'll break the engine or something.

Currently, if you only change the contents of the webserver, you can only use the first four axes out of 6, and the last four buttons out of 10 or 11.