### PR TITLE
Gamepad elements are from now on automatically added from the CSS file.

### DIFF
--- a/yoke/assets/joypad/base.css
+++ b/yoke/assets/joypad/base.css
@@ -3,7 +3,9 @@
 body {
     margin: 0;
     padding: 0;
-    overflow: clip;
+    overflow: hidden;
+    text-align: center;
+    vertical-align: middle;
 }
 
 #joypad {
@@ -11,11 +13,29 @@ body {
     width: 100vw;
     height: 100vh;
 }
+#warning {
+    display: none;
+    position: fixed;
+    width: 64vw;
+    height: 44vh;
+    top: 25vh;
+    left: 15vw;
+    z-index: 1;
+    background: #F0B080;
+    border-radius: 10px;
+    padding: 3vh 3vw 3vh;
+    filter: drop-shadow(0px 0px 5px black)
+}
+.dismiss {
+    margin-top: 5vh;
+    font-size: 80%;
+}
 
 .circle {
-    position: fixed;
+    position: absolute;
     transform: translate(-50%, -50%);
 }
 #dbg {
-    overflow: clip;
+    word-wrap: break-word;
+    overflow: hidden;
 }

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -2,27 +2,102 @@
 // those 3 are recommended for non-kiosk/non-embedded browsers
 let WAIT_FOR_FULLSCREEN = false;
 let DEBUG_NO_SPAM = true;
-let DEBUG_MSG_LABEL = false;
+let DEBUG_MSG_LABEL = true;
 
 let VIBRATION_MILLISECONDS_IN  = 50;
 let VIBRATION_MILLISECONDS_OUT = 50;
+let VELOCITY_CONSTANT = 4000;
 
+//
+// MISCELLANEOUS HELPER FUNCTIONS
+//
+function prettyAlert(message) {
+    let warningDiv = document.getElementById('warning');
+    warningDiv.innerHTML = message + '<p class="dismiss">Tap to dismiss.</p>'
+    warningDiv.style.display = 'inline'
+}
+
+// https://stackoverflow.com/questions/1960473/get-all-unique-values-in-a-javascript-array-remove-duplicates#14438954
+function unique(value, index, self) { 
+    return self.indexOf(value) === index;
+}
+
+function mnemonics(a, b) {
+    let callback, ids
+    if (typeof b == 'function') {
+      // if b is a callback function, mnemonics() chooses the correct control for the joypad
+      callback = b;
+      ids = [a];
+    } else if (typeof b == 'string') {
+      // if b is a string, mnemonics() serves as a custom sorting algorithm
+      callback = null;
+      ids = [a, b]
+    } else {
+      prettyAlert(
+          'FATAL JAVASCRIPT ERROR: \
+          in mnemonics(a, b), b can only be a function or a string.<br>\
+          Please consult the developers.'
+      )
+    }
+    let sortScores = ids.slice();
+    // sortScores contains arbitrary numbers.
+    // These only matter if mnemonics() is being used as a sort function;
+    // the lower-ranking controls are attached earlier.
+    ids.forEach(function (id, i) {
+        if (id == "dbg") {sortScores[i] = 998} else {
+            sortScores[i] = 997;
+            switch (id[0]) {
+                case 'j':
+                    if (typeof callback == 'function') {
+                      sortScores[i] = new Joystick(id, callback);
+                    } else {sortScores[i] = 100};
+                    break
+                case 'm':
+                    if (typeof callback == 'function') {
+                      sortScores[i] = new Motion(id, callback)
+                    } else {sortScores[i] = 200};
+                    break
+                case 'p':
+                    if (typeof callback == 'function') {
+                      sortScores[i] = new Pedal(id, callback)
+                    } else {sortScores[i] = 300};
+                    break
+                case 'b':
+                    if (typeof callback == 'function') {
+                      sortScores[i] = new Button(id, callback)
+                    } else {sortScores[i] = 600};
+                    break
+                default:
+                    sortScores[i] = 999;
+                    prettyAlert('Unrecognised control <code>' + id + '</code> at user.css.');
+                    break
+            }
+            if (sortScores[i] < 990) {sortScores[i] += Number(id.substring(1));};
+        }
+    });
+    if (typeof callback == 'function') {
+      return sortScores[0]
+    } else {
+      if (sortScores[0] < sortScores[1]) {return -1;} else {return 1;}
+    }
+}
+
+//
+// CONTROL DEFINITIONS
+//
 function Control(type, id, updateStateCallback) {
-    //constructor(type, id, updateStateCallback) {
     this.element = document.createElement('div');
     this.element.className = 'control ' + type;
     this.element.id = id;
     this.element.style.gridArea = id;
     this.gridArea = id;
     this.updateStateCallback = updateStateCallback;
-    //}
 }
 Control.prototype.onAttached = function() { };
 Control.prototype.state = function() { };
 
 function Joystick(id, updateStateCallback) {
-    //constructor(id, updateStateCallback) {
-    Control.call(this, 'joystick', 'j' + id, updateStateCallback);
+    Control.call(this, 'joystick', id, updateStateCallback);
     this._stateX = 0.5;
     this._stateY = 0.5;
     this._locking = false;
@@ -31,7 +106,6 @@ function Joystick(id, updateStateCallback) {
     this._circle.className = 'circle';
     this._circle.style.top = '99999px';
     this.element.appendChild(this._circle);
-    //}
 }
 Joystick.prototype = Object.create(Control.prototype);
 Joystick.prototype.onAttached = function() {
@@ -41,6 +115,7 @@ Joystick.prototype.onAttached = function() {
     this.element.addEventListener('touchmove', this.onTouch.bind(this), false);
     this.element.addEventListener('touchstart', this.onTouchStart.bind(this), false);
     this.element.addEventListener('touchend', this.onTouchEnd.bind(this), false);
+    axes += 2;
 }
 Joystick.prototype.onTouch = function(ev) {
     let pos = ev.targetTouches[0];
@@ -76,16 +151,14 @@ Joystick.prototype._updateCircle = function () {
 }
 
 function Button(id, updateStateCallback) {
-    // constructor(id, updateStateCallback) {
-    Control.call(this, 'button', 'b' + id, updateStateCallback);
+    Control.call(this, 'button', id, updateStateCallback);
     this._state = 0;
-    // }
 }
-
 Button.prototype = Object.create(Control.prototype);
 Button.prototype.onAttached = function() {
     this.element.addEventListener('touchstart', this.onTouchStart.bind(this), false);
     this.element.addEventListener('touchend', this.onTouchEnd.bind(this), false);
+    buttons += 1;
 }
 Button.prototype.onTouchStart = function () {
     this._state = 1;
@@ -101,37 +174,98 @@ Button.prototype.state = function () {
     return this._state.toString();
 }
 
-function Compass(id, updateStateCallback) {
-    Control.call(this, 'compass', 'c' + id, updateStateCallback);
+function Motion(id, updateStateCallback) {
+    Control.call(this, 'motion', id, updateStateCallback);
+    this._stateAlpha = 0.5;
     this._stateBeta = 0.5;
     this._stateGamma = 0.5;
+    this._stateX = 0.5;
+    this._stateY = 0.5;
+    this._stateZ = 0.5;
+    this._interval = 0;
+}
+Motion.prototype = Object.create(Control.prototype);
+Motion.prototype._truncate = function(f) {
+    if (f < -0.5) {f = -0.5;};
+    if (f > 0.5) {f = 0.5;};
+    return f + 0.5;
+}
+Motion.prototype.onAttached = function() {
+    window.addEventListener('devicemotion', Motion.prototype.onDeviceMotion.bind(this), true)
+    axes += 2;
+}
+Motion.prototype.onDeviceMotion = function(ev) {
+    this._interval = ev.interval;
+    this._stateAlpha += ev.rotationRate.alpha / 180000 * this._interval;
+    this._stateBeta += ev.rotationRate.beta / 180000 * this._interval;
+    this._stateGamma += ev.rotationRate.gamma / 360000 * this._interval;
+    this._stateX = Motion.prototype._truncate(ev.accelerationIncludingGravity.x / VELOCITY_CONSTANT * this._interval);
+    this._stateY = Motion.prototype._truncate(ev.accelerationIncludingGravity.y / VELOCITY_CONSTANT * this._interval);
+    this._stateZ = Motion.prototype._truncate(ev.accelerationIncludingGravity.z / VELOCITY_CONSTANT * this._interval);
+    this.updateStateCallback();
+}
+Motion.prototype.onDeviceOrientation = function(ev) {
+}
+Motion.prototype.state = function () {
+    return this._stateX.toString() + ',' + this._stateGamma.toString();
 }
 
-Compass.prototype = Object.create(Control.prototype);
-Compass.prototype.onAttached = function() {
-    window.addEventListener('devicemotion', Compass.prototype.onDeviceMotion, false)
+function Pedal(id, updateStateCallback) {
+    Control.call(this, 'button', id, updateStateCallback);
+    this._state = 0;
+    this._offset = {};
 }
-Compass.prototype.onDeviceMotion = function(ev) {
-    this._stateGamma = (ev.gamma + 180) / 360;
-    this._stateBeta = (ev.beta + 90) / 180;
+Pedal.prototype = Object.create(Control.prototype);
+Pedal.prototype._truncate = function(f) {
+    if (f < 0) {return 0;};
+    if (f > 1) {return 1;};
+    return f;
 }
-Compass.prototype.state = function () {
-    return this._stateBeta.toString() + ',' + this._stateGamma.toString();
+Pedal.prototype.onAttached = function() {
+    this._offset = this.element.getBoundingClientRect();
+    this.element.addEventListener('touchstart', this.onTouchStart.bind(this), false);
+    this.element.addEventListener('touchmove', this.onTouchMove.bind(this), false);
+    this.element.addEventListener('touchend', this.onTouchEnd.bind(this), false);
+    axes += 1;
+}
+Pedal.prototype.onTouchStart = function (ev) {
+    window.navigator.vibrate(VIBRATION_MILLISECONDS_IN);
+    this.onTouchMove(ev);
+}
+Pedal.prototype.onTouchMove = function (ev) {
+    /*
+    //Some screens can detect finger pressure, but not all, and it's difficult to calibrate and detect support.
+    this._state = ev.touches[0].force;
+    if (this._state == 0) {this.state = 0.5};
+    */
+    // Detection based on Y-coordinate, on the other hand, is intuitive and reliable in any device:
+    let pos = ev.targetTouches[0];
+    this._state = this._truncate((this._offset.y - pos.pageY) / this._offset.height + 1);
+    this.updateStateCallback();
+}
+Pedal.prototype.onTouchEnd = function (ev) {
+    this._state = 0;
+    this.updateStateCallback();
+    window.navigator.vibrate(VIBRATION_MILLISECONDS_OUT);
+}
+Pedal.prototype.state = function () {
+    return this._state.toString();
 }
 
+function Dummy(id, updateStateCallback){
+    Control.call(this, 'dummy', 'dum', updateStateCallback);
+}
+Dummy.prototype = Object.create(Control.prototype);
+Dummy.prototype.onAttached = function() {buttons += 1};
+Dummy.prototype.state = function () { return '0'; }
+
+//
+// JOYPAD
+//
 function Joypad() {
     let updateStateCallback = this.updateState.bind(this);
 
-    this._controls = [
-        new Joystick('l', updateStateCallback),
-        new Joystick('r', updateStateCallback),
-        /* EXPERIMENTAL! If you want to try, comment the right joystick, and uncomment this.
-         * Don't forget to change 'jr' to 'cr' in user.css, too. */
-        // new Compass('r', updateStateCallback),
-    ];
-    for (let i = 1; i <= 32; i++) {
-        this._controls.push(new Button(i, updateStateCallback));
-    }
+    this._controls = [ ];
 
     let joypad = document.getElementById('joypad');
     let gridAreas = getComputedStyle(joypad)
@@ -139,22 +273,34 @@ function Joypad() {
         .split('"').join('')
         .split(' ')
         .filter(function (x) {return x != '' && x != '.'});
-    let thereAreNoControls = true;
+    let controlIDs = gridAreas.sort(mnemonics).filter(unique);
+    controlIDs.forEach(function (id) {
+        if (id != 'dbg') {
+          this._controls.push(mnemonics(id, updateStateCallback))
+        };
+    }, this);
     this._controls.forEach(function (control) {
-        if (gridAreas.includes(control.gridArea)) {
-            joypad.appendChild(control.element);
-            control.onAttached();
-            thereAreNoControls = false;
-        }
+        joypad.appendChild(control.element);
+        control.onAttached();
     });
-    if (thereAreNoControls) {
-        // joypad.style.display = "inline";
-        joypad.innerHTML += "You don't seem to have any controls in your gamepad. Is <code>user.css</code> missing or broken?";
+    if (axes == 0 && buttons == 0) {
+        prettyAlert("You don't seem to have any controls in your gamepad. Is <code>user.css</code> missing or broken?");
     };
+    // This section is to be excised later 
+    if (axes != 4) {
+        prettyAlert('Currently, Yoke requires precisely 4 axes: please edit your CSS to incorporate two joysticks, or one joystick and a motion sensor.')
+    }
+    if (buttons > 32) {
+        prettyAlert('Currently, Yoke allows a maximum of 32 buttons.')
+    } else {
+        for (buttons; buttons < 32; buttons++) {
+            this._controls.push(new Dummy('dum', updateStateCallback));
+        }
+    }
+    // end of section to be deleted
 
     if (DEBUG_MSG_LABEL) {
         this._debugLabel = new Control('debug', 'dbg');
-        this._debugLabel.element.style.wordWrap = "break-word";
         joypad.appendChild(this._debugLabel.element);
     }
 }
@@ -171,8 +317,13 @@ Joypad.prototype.updateState = function () {
     }
 }
 
+//
+// BASE CODE
+//
 let joypad = null;
 let btn = null;
+let buttons = 0; // number of buttons total
+let axes = 0; // number of analog axes total
 
 window.addEventListener('resize', function () {
     if(joypad != null){
@@ -183,8 +334,10 @@ window.addEventListener('resize', function () {
 })
 
 window.addEventListener('load', function () {
+    let warningDiv = document.getElementById('warning')
     if (window.CSS && CSS.supports('display', 'grid')) {
-        document.getElementById('joypad').innerHTML = '';
+        warningDiv.addEventListener('click', function () {warningDiv.style.display = 'none'}, false);
+        warningDiv.style.display = 'none';
     };
     let el = document.documentElement;
     let rfs = el.requestFullScreen

--- a/yoke/assets/joypad/main.html
+++ b/yoke/assets/joypad/main.html
@@ -9,7 +9,8 @@
 </head>
 
 <body>
-    <div id="joypad">If you don't see any controls, please <a href="https://play.google.com/store/apps/details?id=com.google.android.webview">upgrade Android WebView</a>, then reboot your device.</div>
+    <div id="joypad"></div>
+    <div id="warning">If you don't see any controls, please <a href="https://play.google.com/store/apps/details?id=com.google.android.webview">upgrade Android WebView</a>, then reboot your device.</div>
     <script type="application/javascript" src="base.js"></script>
 </body>
 

--- a/yoke/assets/joypad/user-default.css
+++ b/yoke/assets/joypad/user-default.css
@@ -1,5 +1,5 @@
-/* These are the default settings, PLEASE DO NOT MODIFY.
-Copy this file to user.css and change that. */
+/* Default settings for the joypad.
+ Please do not change this file. Make a copy called user.css and change that. */
 
 #joypad {
     grid-template-columns: repeat(16, 1fr);
@@ -8,19 +8,19 @@ Copy this file to user.css and change that. */
     /* The map below must match the number of rows and columns specified above: */
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
         ".   .   .   .   .   .   .   .   .   .   .   .   b4  b4  .   .   "
-        ".   jl  jl  jl  .   .   .   .   .   .   .   .   b4  b4  .   .   "
-        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
-        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
-        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
-        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
-        ".   .   .   .   .   .   jr  jr  jr  .   .   .   .   .   .   .   "
+        ".   j1  j1  j1  .   .   .   .   .   .   .   .   b4  b4  .   .   "
+        ".   j1  j1  j1  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   j1  j1  j1  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   .   .   .   .   .   j2  j2  j2  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   j2  j2  j2  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   j2  j2  j2  .   .   .   .   .   .   .   "
         "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
         ;
         /* Possible values:
-         * jl for joystick, left;
-         * jr for joystick, right;
-         * cr for compass (gyrometer), right (VERY EXPERIMENTAL);
-         * b1 to b16 for buttons;
+         * j1, j2, j3... for joystick;
+         * m1 for motion detector (acceleration and rotation, EXPERIMENTAL);
+         * p1, p2... for pedals;
+         * b1 to b32 for buttons;
          * dbg for debug messages;
          * a period for empty space.
          More to come */
@@ -37,15 +37,19 @@ Copy this file to user.css and change that. */
     border-radius: 100%;
 }
 
-#jl {
+#j1 {
     /* Uncomment the line below if you don't want the joystick to return to center when let go */
-    /* animation-name: blocking; */
+    /* animation-name: locking; */
 }
-#jr {
+#j2 {
     /* Uncomment the line below if you don't want the joystick to return to center when let go */
-    animation-name: blocking;
+    animation-name: locking;
 }
-#cr {background-color: #dddddd;}
+
+#p1 {background-color: #444444;}
+#p2 {background-color: #444444;}
+
+#m1 {background-color: #dddddd;}
 
 #b1 {background-color: #2222ee;}
 #b2 {background-color: #ee0000;}

--- a/yoke/assets/joypad/user.css
+++ b/yoke/assets/joypad/user.css
@@ -1,6 +1,4 @@
-/* Settings that the user may want to modify.
- A copy of this file is bundled with yoke, named user-default.css
- Please use that copy as a backup if your controller stops working. */
+/* Settings the user may want to change. */
 
 #joypad {
     grid-template-columns: repeat(16, 1fr);
@@ -9,19 +7,19 @@
     /* The map below must match the number of rows and columns specified above: */
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
         ".   .   .   .   .   .   .   .   .   .   .   .   b4  b4  .   .   "
-        ".   jl  jl  jl  .   .   .   .   .   .   .   .   b4  b4  .   .   "
-        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
-        ".   jl  jl  jl  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
-        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
-        ".   .   .   .   .   .   jr  jr  jr  .   .   .   b1  b1  .   .   "
-        ".   .   .   .   .   .   jr  jr  jr  .   .   .   .   .   .   .   "
+        ".   j1  j1  j1  .   .   .   .   .   .   .   .   b4  b4  .   .   "
+        ".   j1  j1  j1  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   j1  j1  j1  .   .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   .   .   .   .   .   j2  j2  j2  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   j2  j2  j2  .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   j2  j2  j2  .   .   .   .   .   .   .   "
         "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
         ;
         /* Possible values:
-         * jl for joystick, left;
-         * jr for joystick, right;
-         * cr for compass (gyrometer), right (VERY EXPERIMENTAL);
-         * b1 to b16 for buttons;
+         * j1, j2, j3... for joystick;
+         * m1 for motion detector (acceleration and rotation, EXPERIMENTAL);
+         * p1, p2... for pedals;
+         * b1 to b32 for buttons;
          * dbg for debug messages;
          * a period for empty space.
          More to come */
@@ -38,16 +36,19 @@
     border-radius: 100%;
 }
 
-#jl {
+#j1 {
     /* Uncomment the line below if you don't want the joystick to return to center when let go */
-    /* animation-name: blocking; */
+    /* animation-name: locking; */
 }
-#jr {
+#j2 {
     /* Uncomment the line below if you don't want the joystick to return to center when let go */
-    animation-name: blocking;
+    animation-name: locking;
 }
 
-#cr {background-color: #dddddd;}
+#p1 {background-color: #444444;}
+#p2 {background-color: #444444;}
+
+#m1 {background-color: #dddddd;}
 
 #b1 {background-color: #2222ee;}
 #b2 {background-color: #ee0000;}


### PR DESCRIPTION
I'm sorry for merging from the master branch this time. I've got to learn how to use well the `git` command.

I've made some more changes to the web interface:

**New control type: gas pedal.** You press the pedal with the finger, and you can slide it higher to increase your pressure, or lower to decrease it. (Internally, it works like a joystick with no X-asis, but it goes from 0 to 1 and rests at 0.)
- There is also commented code to react to the real finger pressure. I was about to make it the default, but not every touchscreen supports this; the ones which do are very differently calibrated from device to device. Also, "zero-pressure" touch events (like hovering a stylus over a screen) and touch events without pressure information (like the ones in a simple, cheap touchscreen) are both reported the same way; I'm not sure if this is something to worry about.

**Controls are now changed in the CSS file, no JS editing needed.** The script now reads the grid-areas in the CSS file, guesses the intended controls from the first letter of the abbreviation (`j` for joystick, `b` for button, etc.), and attaches them to the joypad in these order: joysticks, motion sensors, pedals, buttons. Both CSS files are bundled with basic instructions.
- A motion sensor are only added when included in the grid-areas, but it's not polished yet, or guaranteed to work, and it still needs to be configured by changing the script itself.

For the moment, to prevent errors in the Python code for the moment, **the web interface expects exactly four analog axes to be registered in the CSS file** (counting joysticks, pedals, and motion sensors). If there are more (or less) than 4, it warns you, but doesn't stop you.
- If there are less than 32 buttons, instead of warning you, it adds dummy controllers which always report `0` as their state. These dummies don't cover any area or create more event listeners.