### PR TITLE
Fix bug with dummy controls.

### DIFF
--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -546,7 +546,6 @@ Button.prototype.onTouchEnd = function() {
 
 function Dummy(id, updateStateCallback) {
     Control.call(this, 'dummy', 'dum', updateStateCallback);
-    buttons += 1;
 }
 Dummy.prototype = Object.create(Control.prototype);
 
@@ -577,11 +576,6 @@ function Joypad() {
         this.element.appendChild(control.element);
         control.onAttached();
     }, this);
-    var kernelEvents = this._controls.map(function(control) { return control.kernelEvent; }).join(',');
-    if (this._debugLabel != null) {
-        this._debugLabel.element.innerHTML = kernelEvents;
-    }
-    if (!DEBUG_NO_CONSOLE_SPAM) { console.log(kernelEvents); }
     if (axes == 0 && buttons == 0) {
         prettyAlert('Your gamepad looks empty. Is <code>user.css</code> missing or broken?');
     }
@@ -593,14 +587,19 @@ function Joypad() {
             this._controls.splice(axes, 0, new Dummy('dum', updateStateCallback));
         }
     }
-    if (buttons > 32) {
-        prettyAlert('Currently, Yoke allows a maximum of 32 buttons. Please edit your CSS.');
+    if (buttons > 15) {
+        prettyAlert('Currently, Yoke allows a maximum of 15 buttons. Please edit your CSS.');
     } else {
-        for (buttons; buttons < 32; buttons++) {
+        for (buttons; buttons < 15; buttons++) {
             this._controls.push(new Dummy('dum', updateStateCallback));
         }
     }
     // End of section to be deleted.
+    var kernelEvents = this._controls.map(function(control) { return control.kernelEvent; }).join(',');
+    if (this._debugLabel != null) {
+        this._debugLabel.element.innerHTML = kernelEvents;
+    }
+    if (!DEBUG_NO_CONSOLE_SPAM) { console.log(kernelEvents); }
     checkVibration();
 }
 Joypad.prototype.updateState = function() {


### PR DESCRIPTION
Dummy buttons are now correctly counted, all dummy controls are reported before sending any event (with an empty kernel event) and the webpage now sends 4 axes and 15 buttons with any layout.