### PR TITLE
Several improvements on the JS side.

### DIFF
--- a/yoke/assets/joypad/base.css
+++ b/yoke/assets/joypad/base.css
@@ -122,27 +122,27 @@ div {
 /* Buttons */
 .button { background-color: #bbb; }
 .pressed { filter: brightness(70%); }
-/* seq 1 16 | xargs -I xx echo "#bxx { background-image: url('img/xx.svg'); }" */
+/* seq 1 16 | xargs -I xx echo "#bxx { background-image: url('img/bxx.svg'); }" */
 /* Some edits done by hand */
-#b1 { background-image: url('img/1.svg'); background-color: #00d; }
-#b2 { background-image: url('img/2.svg'); background-color: #e00; }
-#b3 { background-image: url('img/3.svg'); background-color: #dd0; }
-#b4 { background-image: url('img/4.svg'); background-color: #0d0; }
-#b5 { background-image: url('img/5.svg'); }
-#b6 { background-image: url('img/6.svg'); }
-#b7 { background-image: url('img/7.svg'); }
-#b8 { background-image: url('img/8.svg'); }
-#b9 { background-image: url('img/9.svg'); }
-#b10 { background-image: url('img/10.svg'); }
-#b11 { background-image: url('img/11.svg'); }
-#b12 { background-image: url('img/12.svg'); }
-#b13 { background-image: url('img/13.svg'); }
-#b14 { background-image: url('img/14.svg'); }
-#b15 { background-image: url('img/15.svg'); }
-#b16 { background-image: url('img/16.svg'); }
-#bg { background-image: url('img/g.svg'); background-color: #444; }
-#bs { background-image: url('img/s.svg'); background-color: #444; }
-#bm { background-image: url('img/m.svg'); background-color: #444; }
+#b1 { background-image: url('img/b1.svg'); background-color: #00d; }
+#b2 { background-image: url('img/b2.svg'); background-color: #e00; }
+#b3 { background-image: url('img/b3.svg'); background-color: #dd0; }
+#b4 { background-image: url('img/b4.svg'); background-color: #0d0; }
+#b5 { background-image: url('img/b5.svg'); }
+#b6 { background-image: url('img/b6.svg'); }
+#b7 { background-image: url('img/b7.svg'); }
+#b8 { background-image: url('img/b8.svg'); }
+#b9 { background-image: url('img/b9.svg'); }
+#b10 { background-image: url('img/b10.svg'); }
+#b11 { background-image: url('img/b11.svg'); }
+#b12 { background-image: url('img/b12.svg'); }
+#b13 { background-image: url('img/b13.svg'); }
+#b14 { background-image: url('img/b14.svg'); }
+#b15 { background-image: url('img/b15.svg'); }
+#b16 { background-image: url('img/b16.svg'); }
+#bg { background-image: url('img/bg.svg'); background-color: #444; }
+#bs { background-image: url('img/bs.svg'); background-color: #444; }
+#bm { background-image: url('img/bm.svg'); background-color: #444; }
 
 /* D-pad */
 #dp {
@@ -150,10 +150,22 @@ div {
 }
 
 /* Analog buttons */
-#a1 { background-color: #66f; }
-#a2 { background-color: #f33; }
-#a3 { background-color: #ff2; }
-#a4 { background-color: #2f2; }
+#a1 { background-image: url('img/a1.svg'); background-color: #66f; }
+#a2 { background-image: url('img/a2.svg'); background-color: #f33; }
+#a3 { background-image: url('img/a3.svg'); background-color: #ff2; }
+#a4 { background-image: url('img/a4.svg'); background-color: #2f2; }
+#a5 { background-image: url('img/a5.svg'); }
+#a6 { background-image: url('img/a6.svg'); }
+#a7 { background-image: url('img/a7.svg'); }
+#a8 { background-image: url('img/a8.svg'); }
+#a9 { background-image: url('img/a9.svg'); }
+#a10 { background-image: url('img/a10.svg'); }
+#a11 { background-image: url('img/a11.svg'); }
+#a12 { background-image: url('img/a12.svg'); }
+#a13 { background-image: url('img/a13.svg'); }
+#a14 { background-image: url('img/a14.svg'); }
+#a15 { background-image: url('img/a15.svg'); }
+#a16 { background-image: url('img/a16.svg'); }
 
 /* Motion controls */
 .motion { background-color: #ddd; }

--- a/yoke/assets/joypad/base.css
+++ b/yoke/assets/joypad/base.css
@@ -156,10 +156,11 @@ div {
 #a4 { background-color: #2f2; }
 
 /* Motion controls */
-.motion {background-color: #ddd;}
+.motion { background-color: #ddd; }
+.motiontrinket { background-image: url('img/motiontrinket.svg') }
 
 /* Pedals */
-.pedal {background-color: #444;}
+.pedal { background-color: #333; }
 
 /* Knobs */
 .knob { }

--- a/yoke/assets/joypad/base.css
+++ b/yoke/assets/joypad/base.css
@@ -143,17 +143,17 @@ div {
 #bg { background-image: url('img/g.svg'); background-color: #444; }
 #bs { background-image: url('img/s.svg'); background-color: #444; }
 #bm { background-image: url('img/m.svg'); background-color: #444; }
-/* printf "du\ndl\ndd\ndr" | xargs -I xx echo "#xx { background-image: url('img/xx.svg'); }" */
-#du { background-image: url('img/du.svg'); }
-#dl { background-image: url('img/dl.svg'); }
-#dd { background-image: url('img/dd.svg'); }
-#dr { background-image: url('img/dr.svg'); }
+
+/* D-pad */
+#dp {
+    background-image: url('img/dp.svg');
+}
 
 /* Analog buttons */
-#a1 {background-color: #66f;}
-#a2 {background-color: #f33;}
-#a3 {background-color: #ff2;}
-#a4 {background-color: #2f2;}
+#a1 { background-color: #66f; }
+#a2 { background-color: #f33; }
+#a3 { background-color: #ff2; }
+#a4 { background-color: #2f2; }
 
 /* Motion controls */
 .motion {background-color: #ddd;}

--- a/yoke/assets/joypad/base.css
+++ b/yoke/assets/joypad/base.css
@@ -145,9 +145,7 @@ div {
 #bm { background-image: url('img/bm.svg'); background-color: #444; }
 
 /* D-pad */
-#dp {
-    background-image: url('img/dp.svg');
-}
+#dp { background-image: url('img/dp.svg'); }
 
 /* Analog buttons */
 #a1 { background-image: url('img/a1.svg'); background-color: #66f; }
@@ -169,11 +167,11 @@ div {
 
 /* Motion controls */
 .motion { background-color: #ddd; }
-.motiontrinket { background-image: url('img/motiontrinket.svg') }
+.motiontrinket { background-image: url('img/motiontrinket.svg'); }
 
 /* Pedals */
 .pedal { background-color: #333; }
 
 /* Knobs */
 .knob { }
-.knobcircle {background-color: #888;}
+.knobcircle { background-color: #888; }

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -10,7 +10,6 @@ var DEBUG_NO_CONSOLE_SPAM = true;
 
 // CONSTANTS:
 var VIBRATION_MILLISECONDS_IN = 40;
-var VIBRATION_MILLISECONDS_OUT = 30;
 var VIBRATION_MILLISECONDS_OVER = 20;
 var VIBRATION_MILLISECONDS_SATURATION = [10, 10];
 var ACCELERATION_CONSTANT = 0.025;
@@ -243,7 +242,6 @@ Joystick.prototype.onTouchEnd = function() {
     }
     this.quadrant = -2;
     unqueueForVibration(this.element.id);
-    window.navigator.vibrate(VIBRATION_MILLISECONDS_OUT);
 };
 Joystick.prototype._updateCircle = function() {
     this._circle.style.transform = 'translate(-50%, -50%) translate(' +
@@ -338,7 +336,6 @@ Pedal.prototype.onTouchEnd = function() {
     this._state = 0;
     this.updateStateCallback();
     unqueueForVibration(this.element.id);
-    window.navigator.vibrate(VIBRATION_MILLISECONDS_OUT);
     this.element.classList.remove('pressed');
 };
 
@@ -387,7 +384,6 @@ AnalogButton.prototype.onTouchMoveForce = function(ev) {
 AnalogButton.prototype.onTouchEnd = function() {
     this._state = 0;
     this.updateStateCallback();
-    window.navigator.vibrate(VIBRATION_MILLISECONDS_OUT);
     this.element.classList.remove('pressed');
 };
 
@@ -445,7 +441,6 @@ Knob.prototype.onTouchStart = function(ev) {
 Knob.prototype.onTouchEnd = function() {
     this.updateStateCallback();
     this.initState = this._state;
-    window.navigator.vibrate(VIBRATION_MILLISECONDS_OUT);
     this._updateCircles();
 };
 Knob.prototype._updateCircles = function() {
@@ -474,7 +469,6 @@ Button.prototype.onTouchEnd = function() {
     this._state = 0;
     this.updateStateCallback();
     this.element.classList.remove('pressed');
-    window.navigator.vibrate(VIBRATION_MILLISECONDS_OUT);
 };
 Button.prototype.state = function() { return this._state; };
 

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -1,24 +1,27 @@
 'use strict';
 
-// Settings:
+// SETTINGS:
 var VIBRATE_ON_QUADRANT_BOUNDARY = true;
 var VIBRATE_ON_PAD_BOUNDARY = true;
-
-// Code:
-
 // These 2 options are recommended for testing in non-kiosk/non-embedded browsers:
 var WAIT_FOR_FULLSCREEN = true;
 var DEBUG_NO_CONSOLE_SPAM = true;
 
+// CONSTANTS:
 var VIBRATION_MILLISECONDS_IN = 40;
 var VIBRATION_MILLISECONDS_OUT = 30;
 var VIBRATION_MILLISECONDS_OVER = 40;
 var VIBRATION_MILLISECONDS_SATURATION = [10, 10];
 var ACCELERATION_CONSTANT = 0.025;
 
-//
-// MISCELLANEOUS HELPER FUNCTIONS
-//
+// HELPER FUNCTIONS:
+// Within the Yoke webview, Yoke.update_vals() sends the joypad state.
+// Outside the Yoke webview, Yoke.update_vals() is redefined to have no effect.
+// This prevents JavaScript exceptions, and wastes less CPU time when in Yoke:
+if (typeof window.Yoke === 'undefined') {
+    window.Yoke = {update_vals: function() {}};
+}
+
 function prettyAlert(message) {
     var warningDiv = document.getElementById('warning');
     warningDiv.innerHTML = message + '<p class=\'dismiss\'>Tap to dismiss.</p>';
@@ -26,104 +29,77 @@ function prettyAlert(message) {
 }
 
 // https://stackoverflow.com/questions/1960473/get-all-unique-values-in-a-javascript-array-remove-duplicates#14438954
-function unique(value, index, self) {
-    return self.indexOf(value) === index;
+function unique(value, index, self) { return self.indexOf(value) === index; }
+
+function mnemonics(id, callback) {
+    // Chooses the correct control for the joypad from its mnemonic code.
+    switch (id[0]) {
+        case 's': case 'j':
+            // 's' is a locking joystick, 'j' - non-locking
+            return new Joystick(id, callback); break;
+        case 'm':
+            var legalLabels = 'xyzabg';
+            if (legalLabels.indexOf(id[1]) == -1) {
+                prettyAlert('Motion detection error: \
+                    Unrecognised coordinate <code>' + id[1] + '</code>.');
+                return null;
+            } else { return new Motion(id, callback); }
+            break;
+        case 'p':
+            var legalLabels = 'abt';
+            if (legalLabels.indexOf(id[1]) == -1) {
+                prettyAlert('<code>' + id + '</code> is not a valid pedal. \
+                    Please use <code>pa</code> or <code>pt</code> for accelerator \
+                    and <code>pb</code> for brakes.');
+                return null;
+            } else { return new Pedal(id, callback); }
+            break;
+        case 'k': return new Knob(id, callback); break;
+        case 'a': return new AnalogButton(id, callback); break;
+        case 'b': return new Button(id, callback); break;
+        case 'd':
+            var legalLabels = 'udlr';
+            if (legalLabels.indexOf(id[1]) == -1) {
+                prettyAlert('D-pad error: \
+                    <code>' + id[1] + '</code> is not a cardinal direction.');
+                return null;
+            } else { return new Button(id, callback); break; }
+        default:
+            prettyAlert('Unrecognised control <code>' + id + '</code> at user.css.');
+            return null; break;
+    }
 }
 
-function mnemonics(a, b) {
-    var callback, ids;
-    if (typeof b == 'function') {
-        // if b is a callback function, mnemonics() chooses the correct control for the joypad
-        callback = b;
-        ids = [a];
-    } else {
-        // if b is a string, mnemonics() serves as a custom sorting algorithm
-        callback = null;
-        ids = [a, b];
-    }
+function categories(a, b) {
+    // Custom algorithm to sort control mnemonics.
+    var ids = [a, b];
     var sortScores = ids.slice();
-    // sortScores contains arbitrary numbers.
-    // These only matter if mnemonics() is being used as a sort function;
-    // the lower-ranking controls are attached earlier.
+    // sortScores contains arbitrary numbers. The lower-ranking controls are attached earlier.
     ids.forEach(function(id, i) {
         if (id == 'dbg') { sortScores[i] = 999998; } else {
             sortScores[i] = 999997;
             switch (id[0]) {
-                case 's': case 'j':
-                    // 's' is a locking joystick, 'j' - non-locking
-                    if (typeof callback == 'function') {
-                        sortScores[i] = new Joystick(id, callback);
-                    } else { sortScores[i] = 100000; }
-                    break;
-                case 'm':
-                    if (typeof callback == 'function') {
-                        sortScores[i] = new Motion(id, callback);
-                        switch (id[1]) {
-                            case 'x': case 'y': case 'z': case 'a': case 'b': case 'g': break;
-                            default:
-                                prettyAlert('Motion detection error: \
-                                    Unrecognised coordinate <code>' + id[1] + '</code>.');
-                                break;
-                        }
-                    } else { sortScores[i] = 200000; }
-                    break;
-                case 'p':
-                    if (typeof callback == 'function') {
-                        sortScores[i] = new Pedal(id, callback);
-                        switch (id[1]) {
-                            case 'a': case 'b': case 't': break;
-                            default:
-                                prettyAlert('<code>' + id + '</code> is not a valid pedal. \
-                                    Please use <code>pa</code> or <code>pt</code> for accelerator \
-                                    and <code>pb</code> for brakes.');
-                                break;
-                        }
-                    } else { sortScores[i] = 300000; }
-                    break;
-                case 'k':
-                    if (typeof callback == 'function') {
-                        sortScores[i] = new Knob(id, callback);
-                    } else { sortScores[i] = 400000; }
-                    break;
-                case 'a':
-                    if (typeof callback == 'function') {
-                        sortScores[i] = new AnalogButton(id, callback);
-                    } else { sortScores[i] = 500000; }
-                    break;
-                case 'b':
-                    if (typeof callback == 'function') {
-                        sortScores[i] = new Button(id, callback);
-                    } else { sortScores[i] = 600000; }
-                    break;
-                case 'd':
-                    if (typeof callback == 'function') {
-                        sortScores[i] = new Button(id, callback);
-                        switch (id[1]) {
-                            case 'u': case 'd': case 'l': case 'r': break;
-                            default:
-                                prettyAlert('D-pad error: \
-                                    <code>' + id[1] + '</code> is not a cardinal direction.');
-                                break;
-                        }
-                    } else { sortScores[i] = 700000; }
-                    break;
-                default:
-                    sortScores[i] = 999999;
-                    prettyAlert('Unrecognised control <code>' + id + '</code> at user.css.');
-                    break;
+                // 's' is a locking joystick, 'j' - non-locking
+                case 's': case 'j': sortScores[i] = 100000; break;
+                case 'm': sortScores[i] = 200000; break;
+                case 'p': sortScores[i] = 300000; break;
+                case 'k': sortScores[i] = 400000; break;
+                case 'a': sortScores[i] = 500000; break;
+                case 'b': sortScores[i] = 600000; break;
+                case 'd': sortScores[i] = 700000; break;
+                default: sortScores[i] = 999999999; break;
             }
             if (sortScores[i] < 999990) {
                 // This line should sort controls in the same category by id length,
                 // and after that, by the ASCII codes in the id tag
-                // (the first letter may be different without changing the category)
-                // This shortcut reorders non-negative integers correctly, and letters with the same capitalization in alphabetical order.
+                // This shortcut reorders non-negative integers at the end of a mnemonic correctly,
+                // and letters with the same capitalization in alphabetical order.
                 sortScores[i] += id.substring(1).split('')
                     .reduce(function(acc, cur) {return 256 * acc + cur.charCodeAt();}, 0);
             }
         }
     });
-    if (typeof callback == 'function') { return sortScores[0]; }
-    else { return (sortScores[0] < sortScores[1]) ? -1 : 1; }
+    return (sortScores[0] < sortScores[1]) ? -1 : 1;
 }
 
 function truncate(f, id, pattern) {
@@ -139,18 +115,26 @@ function truncate(f, id, pattern) {
     return f;
 }
 
-// Functions to mix haptic feedback from every element at a high level.
-
+// HAPTIC FEEDBACK MIXING:
 var vibrating = {};
 
 function queueForVibration(id, pattern) {
-    if (!(id in vibrating)) {vibrating[id] = {time: performance.now(), pulse: pattern[0], pause: pattern[1], kill: false};}
+    if (!(id in vibrating)) {
+        vibrating[id] = {
+            time: performance.now(),
+            pulse: pattern[0],
+            pause: pattern[1],
+            kill: false
+        };
+    }
 }
+
 function unqueueForVibration(id) {
-    if (id in vibrating) {vibrating[id].kill = true;}
+    if (id in vibrating) { vibrating[id].kill = true; }
     // And wait for checkVibration to kill it.
     // This is heavier for the browser, but also avoids race conditions between checkVibration() and unqueueForVibration().
 }
+
 function checkVibration() {
     for (var id in vibrating) {
         if (vibrating[id].kill) {
@@ -163,9 +147,7 @@ function checkVibration() {
     window.requestAnimationFrame(checkVibration);
 }
 
-//
-// CONTROL DEFINITIONS
-//
+// GAMEPAD CONTROLS:
 function Control(type, id, updateStateCallback) {
     this.element = document.createElement('div');
     this.element.className = 'control ' + type;
@@ -174,6 +156,7 @@ function Control(type, id, updateStateCallback) {
     this.gridArea = id;
     this.updateStateCallback = updateStateCallback;
     this._state = 0;
+    this.shape = 'rectangle';
 }
 Control.prototype.getBoundingClientRect = function() {
     this._offset = this.element.getBoundingClientRect();
@@ -181,6 +164,19 @@ Control.prototype.getBoundingClientRect = function() {
     this._offset.semiheight = this._offset.height / 2;
     this._offset.xCenter = this._offset.x + this._offset.semiwidth;
     this._offset.yCenter = this._offset.y + this._offset.semiheight;
+    if (this.shape == 'square') {
+        if (this._offset.width < this._offset.height) {
+            this._offset.y += this._offset.semiheight - this._offset.semiwidth;
+            this._offset.height = this._offset.width;
+            this._offset.semiheight = this._offset.semiwidth;
+        } else {
+            this._offset.x += this._offset.semiwidth - this._offset.semiheight;
+            this._offset.width = this._offset.height;
+            this._offset.semiwidth = this._offset.semiheight;
+        }
+    }
+    this._offset.xMax = this._offset.x + this._offset.width;
+    this._offset.yMax = this._offset.y + this._offset.height;
 };
 Control.prototype.onAttached = function() {};
 Control.prototype.state = function() {
@@ -254,18 +250,8 @@ function Motion(id, updateStateCallback) {
     // but maybe it's not the most performant.
     // Motion calculates always every coordinate, then applies a mask on it.
     if (id.length != 2) { prettyAlert('Please use only one coordinate per motion sensor.'); }
-    this._mask = null;
-    switch (id[1]) {
-        case 'x': this._mask = 0; break;
-        case 'y': this._mask = 1; break;
-        case 'z': this._mask = 2; break;
-        case 'a': this._mask = 3; break;
-        case 'b': this._mask = 4; break;
-        case 'g': this._mask = 5; break;
-        default:
-            prettyAlert('Motion detection error: Unrecognised coordinate <code>' + id[1] + '</code>.');
-            break;
-    }
+    var legallabels = 'xyzabg';
+    this._mask = legallabels.indexOf(id[1]);
     // Only the last defined sensor sends events.
     // It's a really hacky and ugly method, but all the motion information
     // is a property of the window anyways, not of any Motion instance.
@@ -395,6 +381,7 @@ AnalogButton.prototype.onTouchEnd = function() {
 
 function Knob(id, updateStateCallback) {
     Control.call(this, 'knob', id, updateStateCallback);
+    this.shape = 'square';
     this._state = 0;
     this._knobcircle = document.createElement('div');
     this._knobcircle.className = 'knobcircle';
@@ -407,15 +394,6 @@ function Knob(id, updateStateCallback) {
 Knob.prototype = Object.create(Control.prototype);
 Knob.prototype.onAttached = function() {
     // Centering the knob within the boundary.
-    if (this._offset.width < this._offset.height) {
-        this._offset.y += this._offset.semiheight - this._offset.semiwidth;
-        this._offset.height = this._offset.width;
-        this._offset.semiheight = this._offset.semiwidth;
-    } else {
-        this._offset.x += this._offset.semiwidth - this._offset.semiheight;
-        this._offset.width = this._offset.height;
-        this._offset.semiwidth = this._offset.semiheight;
-    }
     this._knobcircle.style.top = this._offset.y + 'px';
     this._knobcircle.style.left = this._offset.x + 'px';
     this._knobcircle.style.height = this._offset.width + 'px';
@@ -454,7 +432,7 @@ Knob.prototype._updateCircles = function() {
 
 function Button(id, updateStateCallback) {
     Control.call(this, 'button', id, updateStateCallback);
-    this._state = false;
+    this._state = 0;
     buttons += 1;
 }
 Button.prototype = Object.create(Control.prototype);
@@ -465,24 +443,20 @@ Button.prototype.onAttached = function() {
 };
 Button.prototype.onTouchStart = function(ev) {
     ev.preventDefault(); // Android Webview delays the vibration without this.
-    this._state = true;
+    this._state = 1;
     this.updateStateCallback();
     this.element.classList.add('pressed');
     window.navigator.vibrate(VIBRATION_MILLISECONDS_IN);
 };
 Button.prototype.onTouchEnd = function() {
-    this._state = false;
+    this._state = 0;
     this.updateStateCallback();
     this.element.classList.remove('pressed');
     window.navigator.vibrate(VIBRATION_MILLISECONDS_OUT);
 };
-Button.prototype.state = function() {
-    return (this._state ? 1 : 0);
-};
+Button.prototype.state = function() { return this._state; };
 
-//
-// JOYPAD
-//
+// JOYPAD:
 function Joypad() {
     var updateStateCallback = this.updateState.bind(this);
 
@@ -493,11 +467,18 @@ function Joypad() {
         .gridTemplateAreas
         .split('"').join('').split(' ')
         .filter(function(x) { return x != '' && x != '.'; });
-    var controlIDs = gridAreas.sort(mnemonics).filter(unique);
+    var controlIDs = gridAreas.sort(categories).filter(unique);
     this._debugLabel = null;
     controlIDs.forEach(function(id) {
         if (id != 'dbg') {
             this._controls.push(mnemonics(id, updateStateCallback));
+            if (this._controls[this._controls.length - 1] == null) {
+                this._controls.pop() // discard unrecognised controls
+            }
+            this.updateDebugLabel = function(state) {
+                // shadow dummy function with useful function
+                this._debugLabel.element.innerHTML = state;
+            }
         } else if (this._debugLabel == null) {
             this._debugLabel = new Control('debug', 'dbg');
             this.element.appendChild(this._debugLabel.element);
@@ -521,29 +502,14 @@ function Joypad() {
 }
 Joypad.prototype.updateState = function() {
     var state = this._controls.map(function(control) { return control.state(); }).join(',');
-
-    // Within the Yoke webview, sends the joypad state.
-    // Outside the Yoke webview, window.Yoke.update_vals() is redefined to have no effect.
-    // This prevents JavaScript exceptions, and wastes less CPU time when in Yoke:
     window.Yoke.update_vals(state);
-
-    if (this._debugLabel != null) {
-        this._debugLabel.element.innerHTML = state;
-    }
-
+    this.updateDebugLabel(state);
     if (!DEBUG_NO_CONSOLE_SPAM) { console.log(state); }
 };
+Joypad.prototype.updateDebugLabel = function() { } //dummy function
 
-//
-// BASE CODE
-//
-
-// Dummy Yoke.update_vals function.
-if (typeof window.Yoke === 'undefined') {
-    window.Yoke = {update_vals: function() {}};
-}
-
-// These variables are automatically updated by the code
+// BASE CODE:
+// These variables are automatically updated by the code:
 var joypad = null;
 var buttons = 0; // number of buttons total
 var axes = 0; // number of analog axes total

--- a/yoke/assets/joypad/dpad.css
+++ b/yoke/assets/joypad/dpad.css
@@ -4,7 +4,9 @@
     grid-template-columns: repeat(16, 1fr);
     grid-template-rows: repeat(9, 1fr);
     grid-template-areas:
-    /* The map below must match the number of rows and columns specified above: */
+    /* The map below must match the number of rows and columns specified above.
+     * Controls may cover any rectangular area.
+     * Do not try drawing non-rectangular shapes. */
         "b5  b5  b5  b5  .   .   .   .   .   .   .   .   b6  b6  b6  b6  "
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
         ".   .   .   .   .   .   .    .  .   .   .   .   b4  b4  .   .   "
@@ -17,7 +19,7 @@
         ;
         /* Possible values:
          * j1, j2, j3... for joystick (returns to center when released);
-         * s1, s2, s3... for joystick (stays in place when released);
+         * s1, s2, s3... for sticky joystick (stays in place when released);
          * m_ for motion detector, where _ is one of these letters:
               * x for acceleration in the X-axis (left to right),
               * y for acceleration in the Y-axis (bottom to top),
@@ -33,11 +35,7 @@
               * m for the branded button (HOME or equivalent),
               * 1, 2, 3, 4, 5, 6, 7, 8, 9, 10... for the rest.
          * a_ for analog button/trigger, where _ is a number;
-         * d_ for D-pad, where _ is one of these letters:
-              * u, for the key UP,
-              * d, for the key DOWN,
-              * l, for the key LEFT,
-              * r, for the key RIGHT;
+         * dp for D-pad;
          * dbg for debug messages;
          * a period for empty space. */
 }

--- a/yoke/assets/joypad/dpad.css
+++ b/yoke/assets/joypad/dpad.css
@@ -7,12 +7,12 @@
     /* The map below must match the number of rows and columns specified above: */
         "b5  b5  b5  b5  .   .   .   .   .   .   .   .   b6  b6  b6  b6  "
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
-        ".   .   du  du  .   .   .    .  .   .   .   .   b4  b4  .   .   "
-        ".   .   du  du  .   .   .   bg  bg  .   .   .   b4  b4  .   .   "
-        "dl  dl  .   .   dr  dr  .   .   .   .   b3  b3  .   .   b2  b2  "
-        "dl  dl  .   .   dr  dr  .   bs  bs  .   b3  b3  .   .   b2  b2  "
-        ".   .   dd  dd  .   .   .   .   .   .   .   .   b1  b1  .   .   "
-        ".   .   dd  dd  .   .   .   .   .   .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   .    .  .   .   .   .   b4  b4  .   .   "
+        ".   dp  dp  dp  dp  .   .   bg  bg  .   .   .   b4  b4  .   .   "
+        ".   dp  dp  dp  dp  .   .   .   .   .   b3  b3  .   .   b2  b2  "
+        ".   dp  dp  dp  dp  .   .   bs  bs  .   b3  b3  .   .   b2  b2  "
+        ".   dp  dp  dp  dp  .   .   .   .   .   .   .   b1  b1  .   .   "
+        ".   .   .   .   .   .   .   .   .   .   .   .   b1  b1  .   .   "
         "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
         ;
         /* Possible values:

--- a/yoke/assets/joypad/gamepad.css
+++ b/yoke/assets/joypad/gamepad.css
@@ -4,7 +4,9 @@
     grid-template-columns: repeat(16, 1fr);
     grid-template-rows: repeat(9, 1fr);
     grid-template-areas:
-    /* The map below must match the number of rows and columns specified above: */
+    /* The map below must match the number of rows and columns specified above.
+     * Controls may cover any rectangular area.
+     * Do not try drawing non-rectangular shapes. */
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
         ".   .   .   .   .   .   .   .   .   .   .   .   b4  b4  .   .   "
         ".   .   .   .   .   .   .   .   .   .   .   .   b4  b4  .   .   "
@@ -17,7 +19,7 @@
         ;
         /* Possible values:
          * j1, j2, j3... for joystick (returns to center when released);
-         * s1, s2, s3... for joystick (stays in place when released);
+         * s1, s2, s3... for sticky joystick (stays in place when released);
          * m_ for motion detector, where _ is one of these letters:
               * x for acceleration in the X-axis (left to right),
               * y for acceleration in the Y-axis (bottom to top),
@@ -33,11 +35,7 @@
               * m for the branded button (HOME or equivalent),
               * 1, 2, 3, 4, 5, 6, 7, 8, 9, 10... for the rest.
          * a_ for analog button/trigger, where _ is a number;
-         * d_ for D-pad, where _ is one of these letters:
-              * u, for the key UP,
-              * d, for the key DOWN,
-              * l, for the key LEFT,
-              * r, for the key RIGHT;
+         * dp for D-pad;
          * dbg for debug messages;
          * a period for empty space. */
 }

--- a/yoke/assets/joypad/img/1.svg
+++ b/yoke/assets/joypad/img/1.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">1</text>
-</svg>

--- a/yoke/assets/joypad/img/10.svg
+++ b/yoke/assets/joypad/img/10.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">10</text>
-</svg>

--- a/yoke/assets/joypad/img/11.svg
+++ b/yoke/assets/joypad/img/11.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">11</text>
-</svg>

--- a/yoke/assets/joypad/img/12.svg
+++ b/yoke/assets/joypad/img/12.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">12</text>
-</svg>

--- a/yoke/assets/joypad/img/13.svg
+++ b/yoke/assets/joypad/img/13.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">13</text>
-</svg>

--- a/yoke/assets/joypad/img/14.svg
+++ b/yoke/assets/joypad/img/14.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">14</text>
-</svg>

--- a/yoke/assets/joypad/img/15.svg
+++ b/yoke/assets/joypad/img/15.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">15</text>
-</svg>

--- a/yoke/assets/joypad/img/16.svg
+++ b/yoke/assets/joypad/img/16.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">16</text>
-</svg>

--- a/yoke/assets/joypad/img/2.svg
+++ b/yoke/assets/joypad/img/2.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">2</text>
-</svg>

--- a/yoke/assets/joypad/img/3.svg
+++ b/yoke/assets/joypad/img/3.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">3</text>
-</svg>

--- a/yoke/assets/joypad/img/4.svg
+++ b/yoke/assets/joypad/img/4.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">4</text>
-</svg>

--- a/yoke/assets/joypad/img/5.svg
+++ b/yoke/assets/joypad/img/5.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">5</text>
-</svg>

--- a/yoke/assets/joypad/img/6.svg
+++ b/yoke/assets/joypad/img/6.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">6</text>
-</svg>

--- a/yoke/assets/joypad/img/7.svg
+++ b/yoke/assets/joypad/img/7.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">7</text>
-</svg>

--- a/yoke/assets/joypad/img/8.svg
+++ b/yoke/assets/joypad/img/8.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">8</text>
-</svg>

--- a/yoke/assets/joypad/img/9.svg
+++ b/yoke/assets/joypad/img/9.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">9</text>
-</svg>

--- a/yoke/assets/joypad/img/a1.svg
+++ b/yoke/assets/joypad/img/a1.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">1</text>
+</svg>

--- a/yoke/assets/joypad/img/a10.svg
+++ b/yoke/assets/joypad/img/a10.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">10</text>
+</svg>

--- a/yoke/assets/joypad/img/a11.svg
+++ b/yoke/assets/joypad/img/a11.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">11</text>
+</svg>

--- a/yoke/assets/joypad/img/a12.svg
+++ b/yoke/assets/joypad/img/a12.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">12</text>
+</svg>

--- a/yoke/assets/joypad/img/a13.svg
+++ b/yoke/assets/joypad/img/a13.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">13</text>
+</svg>

--- a/yoke/assets/joypad/img/a14.svg
+++ b/yoke/assets/joypad/img/a14.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">14</text>
+</svg>

--- a/yoke/assets/joypad/img/a15.svg
+++ b/yoke/assets/joypad/img/a15.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">15</text>
+</svg>

--- a/yoke/assets/joypad/img/a16.svg
+++ b/yoke/assets/joypad/img/a16.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">16</text>
+</svg>

--- a/yoke/assets/joypad/img/a2.svg
+++ b/yoke/assets/joypad/img/a2.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">2</text>
+</svg>

--- a/yoke/assets/joypad/img/a3.svg
+++ b/yoke/assets/joypad/img/a3.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">3</text>
+</svg>

--- a/yoke/assets/joypad/img/a4.svg
+++ b/yoke/assets/joypad/img/a4.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">4</text>
+</svg>

--- a/yoke/assets/joypad/img/a5.svg
+++ b/yoke/assets/joypad/img/a5.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">5</text>
+</svg>

--- a/yoke/assets/joypad/img/a6.svg
+++ b/yoke/assets/joypad/img/a6.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">6</text>
+</svg>

--- a/yoke/assets/joypad/img/a7.svg
+++ b/yoke/assets/joypad/img/a7.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">7</text>
+</svg>

--- a/yoke/assets/joypad/img/a8.svg
+++ b/yoke/assets/joypad/img/a8.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">8</text>
+</svg>

--- a/yoke/assets/joypad/img/a9.svg
+++ b/yoke/assets/joypad/img/a9.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.2)" stroke-dasharray="210 35" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">9</text>
+</svg>

--- a/yoke/assets/joypad/img/b1.svg
+++ b/yoke/assets/joypad/img/b1.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">1</text>
+</svg>

--- a/yoke/assets/joypad/img/b10.svg
+++ b/yoke/assets/joypad/img/b10.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">10</text>
+</svg>

--- a/yoke/assets/joypad/img/b11.svg
+++ b/yoke/assets/joypad/img/b11.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">11</text>
+</svg>

--- a/yoke/assets/joypad/img/b12.svg
+++ b/yoke/assets/joypad/img/b12.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">12</text>
+</svg>

--- a/yoke/assets/joypad/img/b13.svg
+++ b/yoke/assets/joypad/img/b13.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">13</text>
+</svg>

--- a/yoke/assets/joypad/img/b14.svg
+++ b/yoke/assets/joypad/img/b14.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">14</text>
+</svg>

--- a/yoke/assets/joypad/img/b15.svg
+++ b/yoke/assets/joypad/img/b15.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">15</text>
+</svg>

--- a/yoke/assets/joypad/img/b16.svg
+++ b/yoke/assets/joypad/img/b16.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">16</text>
+</svg>

--- a/yoke/assets/joypad/img/b2.svg
+++ b/yoke/assets/joypad/img/b2.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">2</text>
+</svg>

--- a/yoke/assets/joypad/img/b3.svg
+++ b/yoke/assets/joypad/img/b3.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">3</text>
+</svg>

--- a/yoke/assets/joypad/img/b4.svg
+++ b/yoke/assets/joypad/img/b4.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">4</text>
+</svg>

--- a/yoke/assets/joypad/img/b5.svg
+++ b/yoke/assets/joypad/img/b5.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">5</text>
+</svg>

--- a/yoke/assets/joypad/img/b6.svg
+++ b/yoke/assets/joypad/img/b6.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">6</text>
+</svg>

--- a/yoke/assets/joypad/img/b7.svg
+++ b/yoke/assets/joypad/img/b7.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">7</text>
+</svg>

--- a/yoke/assets/joypad/img/b8.svg
+++ b/yoke/assets/joypad/img/b8.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">8</text>
+</svg>

--- a/yoke/assets/joypad/img/b9.svg
+++ b/yoke/assets/joypad/img/b9.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">9</text>
+</svg>

--- a/yoke/assets/joypad/img/bg.svg
+++ b/yoke/assets/joypad/img/bg.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">G</text>
+</svg>

--- a/yoke/assets/joypad/img/bm.svg
+++ b/yoke/assets/joypad/img/bm.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">M</text>
+</svg>

--- a/yoke/assets/joypad/img/bs.svg
+++ b/yoke/assets/joypad/img/bs.svg
@@ -1,0 +1,4 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="none"/>
+    <text font-weight="bold" text-anchor="middle" font-family="'Noto Serif', serif" font-size="196" y="270" x="200" fill="rgba(255, 255, 255, 0.5)">▶</text>
+</svg>

--- a/yoke/assets/joypad/img/dd.svg
+++ b/yoke/assets/joypad/img/dd.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">↓</text>
-</svg>

--- a/yoke/assets/joypad/img/dl.svg
+++ b/yoke/assets/joypad/img/dl.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">←</text>
-</svg>

--- a/yoke/assets/joypad/img/dp.svg
+++ b/yoke/assets/joypad/img/dp.svg
@@ -1,0 +1,11 @@
+<svg width="300" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+    <symbol id="arrow">
+        <ellipse ry="40" rx="40" cy="50" cx="50" stroke-width="5" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
+        <text font-weight="bold" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="49" y="50" x="50" fill="rgba(255, 255, 255, 0.5)">↑</text>
+    </symbol>
+    <path id="body" fill="rgba(128, 128, 128, 1)" stroke-width="0" d="M 0,100 h 100 v -100 h 100 v 100 h 100 v 100 h -100 v 100 h -100 v -100 h -100 Z" />
+    <use href="#arrow" x="100" y="0"/>
+    <use href="#arrow" x="100" y="200" transform="rotate(180, 150, 250)" />
+    <use href="#arrow" x="0" y="100" transform="rotate(270, 50, 150)" />
+    <use href="#arrow" x="200" y="100" transform="rotate(90, 250, 150) "/>
+</svg>

--- a/yoke/assets/joypad/img/dr.svg
+++ b/yoke/assets/joypad/img/dr.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">→</text>
-</svg>

--- a/yoke/assets/joypad/img/du.svg
+++ b/yoke/assets/joypad/img/du.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">↑</text>
-</svg>

--- a/yoke/assets/joypad/img/g.svg
+++ b/yoke/assets/joypad/img/g.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">G</text>
-</svg>

--- a/yoke/assets/joypad/img/generate.sh
+++ b/yoke/assets/joypad/img/generate.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
-seq 2 16 | xargs -I xx cp 1.svg xx.svg
-seq 2 16 | xargs -I xx sed -i -E "s/1<\/text>/xx<\/text>/g" xx.svg
+seq 2 16 | xargs -I xx cp a1.svg axx.svg
+seq 2 16 | xargs -I xx sed -i -E "s/1<\/text>/xx<\/text>/g" axx.svg
+seq 1 16 | xargs -I xx cp axx.svg bxx.svg
+seq 1 16 | xargs -I xx sed -i 's/stroke-dasharray="210 35" //g' bxx.svg
+seq 1 16 | xargs -I xx sed -i 's/stroke="rgba(255, 255, 255, 0.2)"/stroke="rgba(255, 255, 255, 0.5)"/g' bxx.svg
 
 # ←↓→↑ can be entered on Linux "latin" keyboards (e.g. Polish)
-# using RAlt+Y, RAlt+U, RAlt+I, RAlt+Shift+U, respectively
-printf "du\ndl\ndd\ndr" | xargs -I xx cp 1.svg xx.svg
-sed -i -E "s/1<\/text>/↑<\/text>/g" du.svg
-sed -i -E "s/1<\/text>/←<\/text>/g" dl.svg
-sed -i -E "s/1<\/text>/→<\/text>/g" dr.svg
-sed -i -E "s/1<\/text>/↓<\/text>/g" dd.svg
+# using RAlt+Y, RAlt+U, RAlt+I, RAlt+Shift+U, respectively.
+# The encircled arrows have been incorporated into dp.svg.
+
+# This code will generate the select, start and branded buttons:
+printf "bg\nbm\nbs" | xargs -I xx cp b1.svg xx.svg
+sed -i -E "s/1<\/text>/G<\/text>/g" bg.svg
+sed -i -E "s/1<\/text>/M<\/text>/g" bm.svg
+sed -i -E "s/1<\/text>/▶<\/text>/g" bs.svg

--- a/yoke/assets/joypad/img/m.svg
+++ b/yoke/assets/joypad/img/m.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">M</text>
-</svg>

--- a/yoke/assets/joypad/img/motiontrinket.svg
+++ b/yoke/assets/joypad/img/motiontrinket.svg
@@ -1,0 +1,3 @@
+<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+    <text font-weight="bold" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">M</text>
+</svg>

--- a/yoke/assets/joypad/img/s.svg
+++ b/yoke/assets/joypad/img/s.svg
@@ -1,4 +1,0 @@
-<svg width="400" height="400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
-    <ellipse ry="160" rx="160" cy="200" cx="200" stroke-width="20" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
-    <text font-weight="bold" xml:space="preserve" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="196" y="200" x="200" fill="rgba(255, 255, 255, 0.5)">&#x25b6;</text>
-</svg>

--- a/yoke/assets/joypad/racing.css
+++ b/yoke/assets/joypad/racing.css
@@ -4,7 +4,9 @@
     grid-template-columns: repeat(16, 1fr);
     grid-template-rows: repeat(9, 1fr);
     grid-template-areas:
-    /* The map below must match the number of rows and columns specified above: */
+    /* The map below must match the number of rows and columns specified above.
+     * Controls may cover any rectangular area.
+     * Do not try drawing non-rectangular shapes. */
         ".   .   .   .   .   .   .   mb  mg  .   .   .   .   .   .   .   "
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
         ".   pb  pb  pb  .   b1  .   .   .   .   b2  .   pa  pa  pa  .   "
@@ -17,7 +19,7 @@
         ;
         /* Possible values:
          * j1, j2, j3... for joystick (returns to center when released);
-         * s1, s2, s3... for joystick (stays in place when released);
+         * s1, s2, s3... for sticky joystick (stays in place when released);
          * m_ for motion detector, where _ is one of these letters:
               * x for acceleration in the X-axis (left to right),
               * y for acceleration in the Y-axis (bottom to top),
@@ -33,11 +35,7 @@
               * m for the branded button (HOME or equivalent),
               * 1, 2, 3, 4, 5, 6, 7, 8, 9, 10... for the rest.
          * a_ for analog button/trigger, where _ is a number;
-         * d_ for D-pad, where _ is one of these letters:
-              * u, for the key UP,
-              * d, for the key DOWN,
-              * l, for the key LEFT,
-              * r, for the key RIGHT;
+         * dp for D-pad;
          * dbg for debug messages;
          * a period for empty space. */
 }

--- a/yoke/assets/joypad/racing.css
+++ b/yoke/assets/joypad/racing.css
@@ -8,13 +8,13 @@
      * Controls may cover any rectangular area.
      * Do not try drawing non-rectangular shapes. */
         ".   .   .   .   .   .   .   mb  mg  .   .   .   .   .   .   .   "
-        ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
-        ".   pb  pb  pb  .   b1  .   .   .   .   b2  .   pa  pa  pa  .   "
-        ".   pb  pb  pb  .   b1  .   bg  bs  .   b2  .   pa  pa  pa  .   "
-        ".   pb  pb  pb  .   .   .   .   .   .   .   .   pa  pa  pa  .   "
-        ".   pb  pb  pb  .   b3  .   .   .   .   b4  .   pa  pa  pa  .   "
-        ".   pb  pb  pb  .   b3  .   .   .   .   b4  .   pa  pa  pa  .   "
-        ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
+        ".   .   .   .   dp  dp  dp  .   .   .   b4  .   .   .   .   .   "
+        "pb  pb  pb  .   dp  dp  dp  .   .   b3  .   b2  .   pa  pa  pa  "
+        "pb  pb  pb  .   dp  dp  dp  .   .   .   b1  .   .   pa  pa  pa  "
+        "pb  pb  pb  .   .   .   .   .   .   .   .   .   .   pa  pa  pa  "
+        "pb  pb  pb  b5  .   .   .   bg  bg  .   .   .   b6  pa  pa  pa  "
+        "pb  pb  pb  b5  .   .   .   .   .   .   .   .   b6  pa  pa  pa  "
+        "pb  pb  pb  b5  .   .   .   bs  bs  .   .   .   b6  pa  pa  pa  "
         "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
         ;
         /* Possible values:

--- a/yoke/assets/joypad/testing.css
+++ b/yoke/assets/joypad/testing.css
@@ -4,7 +4,9 @@
     grid-template-columns: repeat(16, 1fr);
     grid-template-rows: repeat(9, 1fr);
     grid-template-areas:
-    /* The map below must match the number of rows and columns specified above: */
+    /* The map below must match the number of rows and columns specified above.
+     * Controls may cover any rectangular area.
+     * Do not try drawing non-rectangular shapes. */
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
@@ -17,7 +19,7 @@
         ;
         /* Possible values:
          * j1, j2, j3... for joystick (returns to center when released);
-         * s1, s2, s3... for joystick (stays in place when released);
+         * s1, s2, s3... for sticky joystick (stays in place when released);
          * m_ for motion detector, where _ is one of these letters:
               * x for acceleration in the X-axis (left to right),
               * y for acceleration in the Y-axis (bottom to top),
@@ -33,11 +35,7 @@
               * m for the branded button (HOME or equivalent),
               * 1, 2, 3, 4, 5, 6, 7, 8, 9, 10... for the rest;
          * a_ for analog button/trigger, where _ is a number;
-         * d_ for D-pad, where _ is one of these letters:
-              * u, for the key UP,
-              * d, for the key DOWN,
-              * l, for the key LEFT,
-              * r, for the key RIGHT;
+         * dp for D-pad;
          * dbg for debug messages;
          * a period for empty space. */
 }

--- a/yoke/assets/joypad/testing.css
+++ b/yoke/assets/joypad/testing.css
@@ -5,9 +5,9 @@
     grid-template-rows: repeat(9, 1fr);
     grid-template-areas:
     /* The map below must match the number of rows and columns specified above: */
-        ".   pa  pa  .   k1  k1  .   .   .   .   .   .   du  .   .   .   "
-        ".   pa  pa  .   k1  k1  .   .   .   .   .   dl  .   dr  .   .   "
-        ".   pa  pa  .   k1  k1  .   .   .   .   .   .   dd  .   .   .   "
+        ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
+        ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
+        ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
         ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
         ".   mz  mz  mz  .   .   .   .   .   .   .   .   .   .   .   .   "
         ".   mz  mz  mz  .   b1  b1  .   bg  .   bs  .   a1  a1  .   .   "

--- a/yoke/service.py
+++ b/yoke/service.py
@@ -64,10 +64,7 @@ ALIAS_TO_EVENT = {
     'b24': 'BTN_THUMB',
     'b25': 'BTN_THUMB2',
     'b26': 'BTN_TRIGGER',
-    'du':  'BTN_DPAD_UP',
-    'dd':  'BTN_DPAD_DOWN',
-    'dl':  'BTN_DPAD_LEFT',
-    'dr':  'BTN_DPAD_RIGHT',
+    'dp':  'BTN_DPAD_UP,BTN_DPAD_LEFT,BTN_DPAD_DOWN,BTN_DPAD_RIGHT',
 }
 
 def get_ip_address():


### PR DESCRIPTION
It looks like I wrote over every file, but I separated my edits into different commits. I'll try to summarize the end result:

Vibrations
------

Yoke won't longer vibrate when releasing a control (no more `VIBRATION_MILLISECONDS_OUT`). Controls still vibrate when touched (`VIBRATION_MILLISECONDS_IN`).

Testing a fast-paced retro game made me realize that, when I release a button, I notice the vibration in the joystick hand. That was confusing and tired my hands in a couple of minutes, because I felt vibrations for half the time. Letting your fingers off the screen is good enough feedback.

I also decreased the vibration on changing quadrants (`VIBRATION_MILLISECONDS_OVER`).

Joysticks
-------

Joysticks now vibrate more strongly the farther you drag your finger off the area. This is a bit more helpful to find your way back to the joystick center without looking at the phone.

This function can be disabled with the flag `VIBRATE_PROPORTIONALLY_TO_DISTANCE` (name pending), so that's one more flag we have to take into account for #33.

Joysticks have now an internal range of [-0.999999, 0.999999] because it makes some calculations easier. I was worried that it would slow down the controls, but it looks fine in emulators under Linux so far. (This only affects the JavaScript side: they're still mapped to [0, 255] for the Python code, so this change shouldn't change gameplay.)

General cleanup
--------

I reversed a couple of decisions in the JS; I removed the vibration queueing from `truncate()` (it would only be useful in pedals and not really worth it) and split `mnemonics()` in two different functions: new `mnemonics()` to one to parse the CSS grid codes and find the relevant control, and `categories()` to sort those codes before sending them to the Python code.

I also moved some things around, added some comments, and improved the alert box in the Yoke webview (I don't issue duplicate warnings anymore, and warnings are queued until the user has read them all. Users shouldn't receive any warnings unless they make a lot of mistakes with their CSS.)

D-pad
---------

This is the change I'm personally most happy with, although it reverses one of my decisions and made me change four of your images. Remember when I said that we could make a working D-pad out of four digital buttons?

I was wrong. Very wrong. The only way to change directions with four buttons was to move your finger away and press a new button, as sliding your finger wouldn't change your direction. This is uncomfortable, and I also noticed later that it made it impossible to move diagonally unless you used two fingers to press two buttons. (Assuming your screen can correctly detect two fingers in the same spot.)

In a real D-pad, you can slide your finger to press different buttons, or even two perpendicular directions with one single finger. To emulate that, Yoke draws a D-pad on a single grid area (code `dp`), and while the finger is on this area, tracks the finger position and checks it against four overlapping hitboxes. Up and down don't overlap in this version, and neither left and right, but you can quite easily move diagonally in games that allow you to.

There's also an extra benefit: the D-pad itself snaps to the grid as usual, but the legs of the D-pad needn't. D-pads can now be two squares wide or four squares wide if we want them to be.

I tried to use CSS masks to allow users to change the background directly from CSS, but I couldn't get it to work in the Webview. For the moment, it's using `dp.svg` as a background, which includes the plus-sign-shaped body and your icons for the old `du`, `dl`... buttons.

Knobs
--------

Knobs are more realistic and easier to use. Before, you had to make sure you put your finger on the small circle, or the knob would instantly turn to meet your finger.

Now you can turn it as a real one. No matter when you touch it, a quarter turn with your finger will always translate to a quarter turn in the Yoke virtual device.

Racing controls and spinners
---------

The racing layout looks a little more like a modern driving wheel controller.

I also added spinners for the gyrometers. They always spin in the opposite direction they measure, so if you incline the screen towards you and have a tile for the gamma angle, the spinner will spin away from you so it looks like it's fixed in perspective.

Or that was the idea. It will never be so life-like, but it's still very helpful for users and developers alike to notice what they're supposed to measure.

(True to my non-existent art skills, the current spinner is a single capital M. You can use a proper icon by replacing `img/motiontrinket.svg`.)

Spinners for the accelerometers don't move or distort yet.

Button icons
--------

I didn't redraw your images for the buttons: I just removed some useless attributes on them, and tweaked the generator. And renamed all of them. That's why it looks like I changed everything.

I also created icons for the analog buttons: they're copies of the ones you created for digital buttons, but the circle is fainter and broken in four pieces.