### PR TITLE
Bug fixes, can press several buttons now. We'll still probably need to tweak this.

### DIFF
--- a/yoke/assets/joypad/base.css
+++ b/yoke/assets/joypad/base.css
@@ -23,7 +23,7 @@ body {
 #warning, #calibration {
     display: none;
     position: fixed;
-    z-index: 1;
+    z-index: 10;
     border-radius: 10px;
     padding: 3vh 3vw 3vh;
     filter: drop-shadow(0px 0px 5px black)
@@ -78,25 +78,6 @@ body {
     font-size: 80%;
 }
 
-.circle {
-    position: absolute;
-    transform: translate(-50%, -50%);
-    top: 0px;
-    left: 0px;
-}
-
-.knobcircle {
-    position: absolute;
-    border-radius: 100%;
-    transform: rotate(0);
-}
-
-.knobcircle > .circle {
-    position: absolute;
-    top: 50%;
-    left: 90%;
-}
-
 #dbg {
     vertical-align: middle;
     overflow: hidden;
@@ -104,24 +85,44 @@ body {
     color: #0f0;
     font-family: monospace;
     word-wrap: break-word;
+    z-index: 2;
 }
 
 div {
     background-size: 100% 100%;
 }
 
+.control { z-index: 2; }
+
 /* Joysticks */
-.joystick { background-image: url("img/joystick.svg"); background-color: #bbb; }
+.joystick {
+    background-image: url("img/joystick.svg");
+    background-color: #bbb;
+}
 .circle {
     background-color: black;
     width: 10px;
     height: 10px;
     border-radius: 100%;
+    z-index: 2;
+    position: absolute;
+    left: 0px;
+    top: 0px;
 }
 
 /* Buttons */
-.button { background-color: #bbb; }
+.analogbutton { background-color: #ccc; z-index: 1; }
+.button { background-color: #bbb; z-index: 1; }
 .pressed { filter: brightness(70%); }
+.buttonhitbox {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    height: 1px;
+    width: 1px;
+    transform-origin: top left;
+    opacity: 0;
+}
 /* seq 1 16 | xargs -I xx echo "#bxx { background-image: url('img/bxx.svg'); }" */
 /* Some edits done by hand */
 #b1 { background-image: url('img/b1.svg'); background-color: #00d; }
@@ -167,11 +168,24 @@ div {
 
 /* Motion controls */
 .motion { background-color: #ddd; }
-.motiontrinket { background-image: url('img/motiontrinket.svg'); }
+.motiontrinket { width: 100%; height: 100%; background-image: url('img/motiontrinket.svg'); }
 
 /* Pedals */
 .pedal { background-color: #333; }
 
 /* Knobs */
 .knob { }
-.knobcircle { background-color: #888; }
+.knobcircle {
+    position: absolute;
+    border-radius: 100%;
+    transform: rotate(0);
+    background-color: #888;
+}
+
+.knobcircle > .circle {
+    position: absolute;
+    top: 50%;
+    left: 90%;
+    transform: translate(-50%, -50%);
+}
+

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -542,8 +542,7 @@ DPad.prototype.onTouchStart = function(ev) {
 };
 DPad.prototype.onTouchMove = function(ev) {
     this._state = [0, 0, 0, 0]; // up, left, down, right
-    for (var i = 0; i < ev.targetTouches.length; i++) {
-        var pos = ev.targetTouches[i];
+    Array.from(ev.targetTouches, function(pos) {
         if (pos.pageX > this._offset.x1 && pos.pageX < this._offset.x2) {
             if (pos.pageY < this._offset.up_y && pos.pageY > this._offset.y) {
                 this._state[0] = 1;
@@ -558,7 +557,7 @@ DPad.prototype.onTouchMove = function(ev) {
                 this._state[3] = 1;
             }
         }
-    }
+    }, this);
     this.updateStateCallback();
     var currentState = this._state.reduce(function(acc, cur) {return (acc << 1) + cur;}, 0);
     if (currentState != this.oldState) {
@@ -678,6 +677,7 @@ function loadPad(filename) {
     window.addEventListener('resize', function() {
         if (joypad != null) {
             joypad._controls.forEach(function(control) {
+                control.getBoundingClientRect();
                 control.onAttached();
             });
         }

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -449,7 +449,10 @@ AnalogButton.prototype.processTouchesForce = function() {
     this._state = 0.000001;
     for (var id in this._currentTouches) {
         var touch = this._currentTouches[id];
-        this._state = Math.max(this._state, touch.force);
+        if (touch.pageX > this._offset.x && touch.pageX < this._offset.xMax &&
+            touch.pageY > this._offset.y && touch.pageY < this._offset.yMax) {
+            this._state = Math.max(this._state, truncate((touch.force - minForce) / (maxForce - minForce)));
+        }
     }
     (this._state == 0.000001) ? this.element.classList.remove('pressed') : this.element.classList.add('pressed');
 }

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -27,6 +27,11 @@ var BUTTON_OVERSHOOT_WIDTH = 7;
 var BUTTON_OVERSHOOT_HEIGHT = 7;
 // To normalize values from accelerometers:
 var ACCELERATION_CONSTANT = 0.025;
+// Multiplier for analog buttons in non-force-detecting mode.
+// (Simulated force is multiplied by this number, and truncated in case of saturation.)
+// The dead zone length/width, relative to the analog button hitbox length/width,
+// will be 1 - (1 / ANALOGBUTTON_DEADZONE_CONSTANT).
+var ANALOGBUTTON_DEADZONE_CONSTANT = 1.10;
 
 // HELPER FUNCTIONS:
 // Within the Yoke webview, Yoke.update_vals() sends the joypad state.
@@ -434,7 +439,7 @@ AnalogButton.prototype.processTouches = function() {
     this._state = 0.000001;
     for (var id in this._currentTouches) {
         var touch = this._currentTouches[id];
-        this._state = Math.max(this._state, truncate(Math.min(
+        this._state = Math.max(this._state, truncate(ANALOGBUTTON_DEADZONE_CONSTANT * Math.min(
             1 - Math.abs((touch.pageY - this._offset.yCenter) / this._offset.halfHeight),
             1 - Math.abs((touch.pageX - this._offset.xCenter) / this._offset.halfWidth)
         )));
@@ -482,9 +487,8 @@ AnalogButton.prototype.onTouchEnd = function(ev) {
 
 function Knob(id, updateStateCallback) {
     Control.call(this, 'knob', id, updateStateCallback);
-    this._state = 0;
-    this.initState = 0; // state at onTouchStart
-    this.initAngle = 0; // angular coordinate at onTouchStart
+    this._state = 0.5;
+    this.initState = 0.5; // state at onTouchStart
     this.initTransform = ''; // style.transform
     this._knobCircle = document.createElement('div');
     this._knobCircle.className = 'knobcircle';
@@ -535,7 +539,7 @@ Knob.prototype.onTouchEnd = function() {
     this._updateCircles();
 };
 Knob.prototype._updateCircles = function() {
-    this._knobCircle.style.transform = 'rotate(' + ((this._state - 0.25) * 360) + 'deg)';
+    this._knobCircle.style.transform = 'rotate(' + ((this._state + 0.25) * 360) + 'deg)';
 };
 
 function Button(id, updateStateCallback) {

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -494,7 +494,6 @@ AnalogButton.prototype.onTouchMove = function(ev) {
         Math.floor(currentState) >= Math.floor(this.oldState)) {
         window.navigator.vibrate(VIBRATION_MILLISECONDS_IN);
     }
-    console.log('TouchMove: ' + currentState + ' → ' + this.oldState);
     this.oldState = currentState;
 };
 AnalogButton.prototype.onTouchEnd = function(ev) {
@@ -504,7 +503,6 @@ AnalogButton.prototype.onTouchEnd = function(ev) {
         });
         return el.processTouches();
     }).reduce(function(acc, cur) {return acc + cur;}, 0);
-    console.log('TouchEnd: ' + this.oldState);
     this.updateStateCallback();
 };
 

--- a/yoke/assets/joypad/base.js
+++ b/yoke/assets/joypad/base.js
@@ -431,7 +431,7 @@ AnalogButton.prototype.onAttached = function() {
         'translate(' + this._offset.x, 'px, ', this._offset.y, 'px) ',
         'scaleX(', this._offset.width, ') ',
         'scaleY(', this._offset.height, ')'
-    ]
+    ];
     this._hitbox.style.transform = transformation.join('');
 };
 AnalogButton.prototype.processTouches = function() {
@@ -444,7 +444,7 @@ AnalogButton.prototype.processTouches = function() {
         )));
     }
     (this._state == 0.000001) ? this.element.classList.remove('pressed') : this.element.classList.add('pressed');
-}
+};
 AnalogButton.prototype.processTouchesForce = function() {
     this._state = 0.000001;
     for (var id in this._currentTouches) {
@@ -455,7 +455,7 @@ AnalogButton.prototype.processTouchesForce = function() {
         }
     }
     (this._state == 0.000001) ? this.element.classList.remove('pressed') : this.element.classList.add('pressed');
-}
+};
 AnalogButton.prototype.onTouchStart = function(ev) {
     ev.preventDefault(); // Android Webview delays the vibration without this.
     this.onTouchMove(ev);
@@ -473,7 +473,7 @@ AnalogButton.prototype.onTouchMove = function(ev) {
         el.processTouches();
     });
     this.updateStateCallback();
-}
+};
 AnalogButton.prototype.onTouchEnd = function(ev) {
     this.neighbourhood.forEach(function(el) {
         Array.from(ev.changedTouches, function(touch) {
@@ -561,7 +561,7 @@ Button.prototype.onAttached = function() {
         'translate(' + this._offset.x, 'px, ', this._offset.y, 'px) ',
         'scaleX(', this._offset.width, ') ',
         'scaleY(', this._offset.height, ')'
-    ]
+    ];
     this._hitbox.style.transform = transformation.join('');
 };
 Button.prototype.processTouches = function() {
@@ -570,11 +570,11 @@ Button.prototype.processTouches = function() {
         var touch = this._currentTouches[id];
         if (touch.pageX > this._offset.x && touch.pageX < this._offset.xMax &&
             touch.pageY > this._offset.y && touch.pageY < this._offset.yMax) {
-                this._state = 1;
+            this._state = 1;
         }
     }
     (this._state == 1) ? this.element.classList.add('pressed') : this.element.classList.remove('pressed');
-}
+};
 Button.prototype.onTouchStart = AnalogButton.prototype.onTouchStart;
 Button.prototype.onTouchMove = AnalogButton.prototype.onTouchMove;
 Button.prototype.onTouchEnd = AnalogButton.prototype.onTouchEnd;
@@ -712,7 +712,7 @@ function Joypad() {
         var id = c.element.id;
         if (id[0] == 'b' || id[0] == 'a') {
             c.neighbourhood = findNeighbourhood(this.gridAreas, c.element.id)
-                .filter(function(x) { return (x[0] == 'b' || x[0] == 'a') });
+                .filter(function(x) { return (x[0] == 'b' || x[0] == 'a'); });
             c.neighbourhood = c.neighbourhood.map(function(x) {
                 return this._controls.byMnemonicID[x];
             }, this);

--- a/yoke/assets/joypad/img/dp.svg
+++ b/yoke/assets/joypad/img/dp.svg
@@ -1,4 +1,4 @@
-<svg width="300" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+<svg width="300" height="300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300" preserveAspectRatio="none">
     <symbol id="arrow">
         <ellipse ry="40" rx="40" cy="50" cx="50" stroke-width="5" stroke="rgba(255, 255, 255, 0.5)" fill="rgba(0, 0, 0, 0)"/>
         <text font-weight="bold" text-anchor="middle" dominant-baseline="central" font-family="'Noto Serif', serif" font-size="49" y="50" x="50" fill="rgba(255, 255, 255, 0.5)">↑</text>

--- a/yoke/assets/joypad/img/joystick.svg
+++ b/yoke/assets/joypad/img/joystick.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1">
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1" preserveAspectRatio="none">
     <defs><style>
         path {
             fill: none;

--- a/yoke/assets/joypad/testing.css
+++ b/yoke/assets/joypad/testing.css
@@ -10,11 +10,11 @@
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
-        ".   .   .   .   .   .   .   .   a1  a1  a1  a1  a2  a2  a2  a2  "
-        ".   mz  mz  b1  b1  b1  b1  b1  a1  a1  a1  a1  a2  a2  a2  a2  "
-        ".   mz  mz  b1  b1  b1  b1  b1  a1  a1  a1  a1  a2  a2  a2  a2  "
-        ".   mz  mz  b1  b1  b1  b1  b1  a1  a1  a1  a1  a2  a2  a2  a2  "
-        ".   .   .   b1  b1  b1  b1  b1  a3  a3  a3  a3  a4  a4  a4  a4  "
+        ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
+        ".   mz  mz  b1  b1  b1  b1  b1  .   a1  a1  a1  .   .   .   .   "
+        ".   mz  mz  b1  b1  b1  b1  b1  .   a1  a1  a1  a2  a2  .   .   "
+        ".   mz  mz  b1  b1  b1  b1  b1  .   a1  a1  a1  a2  a2  .   .   "
+        ".   .   .   b1  b1  b1  b1  b1  .   .   .   a3  a4  a4  a4  a4  "
         "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
         ;
         /* Possible values:

--- a/yoke/assets/joypad/testing.css
+++ b/yoke/assets/joypad/testing.css
@@ -10,11 +10,11 @@
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
         ".   pa  pa  .   k1  k1  .   .   .   .   .   dp  dp  dp  .   .   "
-        ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
-        ".   mz  mz  mz  .   .   .   .   .   .   .   .   .   .   .   .   "
-        ".   mz  mz  mz  .   b1  b1  .   bg  .   bs  .   a1  a1  .   .   "
-        ".   mz  mz  mz  .   b1  b1  .   bg  .   bs  .   a1  a1  .   .   "
-        ".   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   "
+        ".   .   .   .   .   .   .   .   a1  a1  a1  a1  a2  a2  a2  a2  "
+        ".   mz  mz  b1  b1  b1  b1  b1  a1  a1  a1  a1  a2  a2  a2  a2  "
+        ".   mz  mz  b1  b1  b1  b1  b1  a1  a1  a1  a1  a2  a2  a2  a2  "
+        ".   mz  mz  b1  b1  b1  b1  b1  a1  a1  a1  a1  a2  a2  a2  a2  "
+        ".   .   .   b1  b1  b1  b1  b1  a3  a3  a3  a3  a4  a4  a4  a4  "
         "dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg dbg "
         ;
         /* Possible values:

--- a/yoke/vjoy/vjoydevice.py
+++ b/yoke/vjoy/vjoydevice.py
@@ -1,34 +1,17 @@
 import os
 from ctypes import cdll
 import platform
+import struct
 
 class VjoyException(Exception):
     pass
 
-class VjoyConstants:
-    BTN_1 = 1
-    BTN_2 = 2
-    BTN_3 = 3
-    BTN_4 = 4
-    BTN_5 = 5
-    BTN_6 = 6
-    BTN_7 = 7
-    BTN_8 = 8
-
-    ABS_X = 0x30
-    ABS_Y = 0x31
-    ABS_Z = 0x32
-    ABS_RX = 0x33 # rotation
-    ABS_RY = 0x34
-    ABS_RZ = 0x35
-    ABS_SL0 = 0x36  # slider
-    ABS_SL1 = 0x37
-    ABS_WHL = 0x38  # wheel
-    ABS_POV = 0x39
-
 class VjoyDevice:
     def __init__(self, id=None):
         self.id = id
+        self.axes = [0,] * 15
+        self.buttons = 0
+        self.struct = struct.Struct('@B 18L L 4I 3L')
         if platform.release() in ('10', 'post10') and [int(v) for v in platform.version().split('.')[0:3]] > [10, 0, 1803]:
             lib_name = "vJoyInterface-" + platform.architecture()[0] + "-modern.dll"
         else:
@@ -54,10 +37,29 @@ class VjoyDevice:
         self.lib.AcquireVJD(id)
 
     def set_button(self, id, on):
-        return self.lib.SetBtn(on, self.id, id)
-
+        self.buttons |= (on << id)
     def set_axis(self, id, v):
-        return self.lib.SetAxis(v, self.id, id)
-
+        self.axes[id] = ((v << 7) | (v >> 1)) + 1
+    def flush(self, axes, buttons):
+            # Struct JOYSTICK_POSITION_V2's definition can be found at
+            # https://github.com/shauleiz/vJoy/blob/2c9a6f14967083d29f5a294b8f5ac65d3d42ac87/SDK/inc/public.h#L203
+            # It's basically:
+            # 1 BYTE for device ID
+            # 3 unused LONGs
+            # 8 LONGs for axes
+            # 7 unused LONGs
+            # 1 LONGs for buttons
+            # 4 DWORDs for hats
+            # 3 LONGs for buttons
+            self.lib.UpdateVJD(self.id, self.struct.pack(
+                self.id, # 1 BYTE for device ID
+                0, 0, 0, # 3 unused LONGs
+                *axes, # 8 LONGs for axes and 7 unused LONGs
+                buttons & 0xffffffff, # 1 LONG for buttons
+                0, 0, 0, 0, # 4 DWORDs for hats
+                (buttons >> 32) & 0xffffffff,
+                (buttons >> 64) & 0xffffffff,
+                (buttons >> 96) & 0xffffffff # 3 LONGs for buttons
+            ))
     def close(self):
         return self.lib.RelinquishVJD(self.id)


### PR DESCRIPTION
I've tried to separate my edits in different commits, but some of them may have some undocumented code tweaks or bug fix.

Short story:

Graphical fixes
----

At some point I broke `base.css`, so the joysticks were painted far away from their correct positions, and there were multiple double definitions. I think I corrected all of these bugs.

I also made positive to include `preserveAspectRatio="none"` in `joystick.svg` and `dp.svg` so there won't be any mismatch between the background image and the actual control. If we desperately want any of them to be square, we can define `this.shape = 'square'` in the pertinent JS object.

All positions and hitboxes are recalculated now when resizing the window. This won't have much use within the Yoke app, but part of the code was already there, and it's very useful for debugging.

Some changes in variable names
--------

Controls now have multiple references: instead of just accessing `Joypad._controls` as an array, you can now use `Joypad._controls.byMnemonicID` and `Joypad._controls.byNumID`. (I _really_ need to learn to use better names when coding.)

I needed to be able to use both kinds of references: the numeric one is still used for reporting the state from the Yoke app, and the alphanumeric one is used for...

`findNeighbourhood()`
---------

Please rename this as well, if you have a better name.

The only way to be able to press several buttons with just one finger was for them to share events. I thought that reading events directly from `div#joypad` and tracking the finger positions for every button in every touch event would be too slow and too complicated, so I developed this function. It can be tweaked to avoid some repeated calculations, but it's very fast as it's written.

This function finds the mnemonic for the control in the CSS, reads every control that's directly touching it (on edges or corners), and outputs every for them as an array sorted and without duplicates. For example, using findNeighbourhood on `b1` and this layout:

```
b1 b1 b2
b1 b1 .
b4 .  j1
```

will return `['j1', 'b1', 'b2', 'b4', '.']`. Yes, it also outputs itself and the empty squares.

This function is called ahead of time and the controls are referenced in `Button.neighbourhood` (or `AnalogButton.neighbourhood`). The non-button controls are filtered, but every button lists itself in `neighbourhood` because...

Overlapping buttons
----------

The buttons now lay a transparent div `.buttonhitbox`, over the button, and make it slightly bigger. A different method, but for the user it works more or less like the D-pad. The only difference is that the padding of this hitbox is based on absolute pixels instead of fractions of a square. I should probably tweak this, but I wasn't sure how, and decided to leave it to later commits.

Every time one of these hitboxes registers a touch event, it's shared with every button in `neighbourhood`. Every button checks the finger coordinates against its own hitbox, and then the button that received the original touch event runs `updateState()` once, so the computer will register the button presses as simultaneous.

Analog buttons
------

I decided to make some changes to this to make it more intuitive.

If you're using force detection, it uses that, as usual. Every button you press with the same finger reports the same force.

If you're not, it's based in distance to the center, so every pressed button will report different "forces" depending on your finger position.

The real change here is that the engine doesn't check if the button is wide or long beforehand. Analog buttons now check the position on both the X and Y axis, and report the lower one. The only way to press a button with full force when using this system is to touch it in the dead center.

Maybe we could add a dead zone around the center. As the calculated force will be truncated to [0.000001, 0.999999] anyways, multiplying it times 1.05 or some other number should be enough.