### PR TITLE
Improve error printing when uinput is missing or misconfigured

### DIFF
--- a/bin/yoke
+++ b/bin/yoke
@@ -2,6 +2,9 @@
 import yoke
 from yoke import EVENTS
 import argparse
+import sys
+
+sys.tracebacklimit = 3
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--name', type=str, default='Yoke', help='virtual device name')

--- a/yoke/service.py
+++ b/yoke/service.py
@@ -96,9 +96,16 @@ class Device:
         events = [e + (0, 255, 0, 0) if e in ABS_EVENTS else e for e in events]
 
         BUS_VIRTUAL = 0x06
-        import uinput
-
-        self.device = uinput.Device(events, name, BUS_VIRTUAL)
+        try:
+            import uinput
+            self.device = uinput.Device(events, name, BUS_VIRTUAL)
+        except Exception as e:
+            print("Failed to initialize device via uinput.")
+            print("Hint: try loading kernel driver with `sudo modprobe uinput`.")
+            print("Hint: make sure you've run `yoke-enable-uinput` to configure permissions.")
+            print("")
+            print("More info: {}".format(e.args))
+            raise
 
     def emit(self, d, v):
         if d not in self.events:


### PR DESCRIPTION
Applying suggestion from #45 . `yoke` will now print hints on errors.